### PR TITLE
Feature/custom types names

### DIFF
--- a/src/middlewares/json-api-koa.ts
+++ b/src/middlewares/json-api-koa.ts
@@ -3,18 +3,11 @@ import { decode } from "jsonwebtoken";
 import { Context, Middleware } from "koa";
 import * as koaBody from "koa-body";
 import * as compose from "koa-compose";
-
 import Application from "../application";
 import JsonApiErrors from "../json-api-errors";
-import {
-  JsonApiDocument,
-  JsonApiError,
-  JsonApiErrorsDocument,
-  Operation,
-  OperationResponse
-} from "../types";
+import { JsonApiDocument, JsonApiError, JsonApiErrorsDocument, Operation, OperationResponse } from "../types";
 import { parse } from "../utils/json-api-params";
-import { classify, singularize } from "../utils/string";
+import { camelize, singularize } from "../utils/string";
 
 const STATUS_MAPPING = {
   GET: 200,
@@ -38,9 +31,9 @@ export default function jsonApiKoa(
       return await next();
     }
 
-    const typeNames = app.types.map(t => t.name);
+    const typeNames = app.types.map(t => t.type);
 
-    if (typeNames.includes(classify(singularize(data.resource)))) {
+    if (typeNames.includes(camelize(singularize(data.resource)))) {
       ctx.urlData = data;
       return await handleJsonApiEndpoints(app, ctx).then(() => next());
     }
@@ -117,7 +110,7 @@ async function handleJsonApiEndpoints(app: Application, ctx: Context) {
 
 function convertHttpRequestToOperation(ctx: Context): Operation {
   const { id, resource } = ctx.urlData;
-  const type = classify(singularize(resource));
+  const type = camelize(singularize(resource));
 
   const opMap = {
     GET: "get",

--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -1,10 +1,10 @@
 import * as Knex from "knex";
-
 import Resource from "../resource";
 import { KnexRecord, Operation, ResourceConstructor } from "../types";
 import { camelize, pluralize } from "../utils/string";
-
 import OperationProcessor from "./operation-processor";
+
+
 
 const operators = {
   eq: "=",
@@ -63,7 +63,7 @@ export default class KnexProcessor<
     const resource = Object.create(this.resourceFor(type));
     const fields = params ? { ...params.fields } : {};
     const attributes = getAttributes(
-      Object.keys(resource.__proto__.attributes),
+      Object.keys(resource.__proto__.attributes || {}),
       fields,
       type
     );

--- a/src/processors/operation-processor.ts
+++ b/src/processors/operation-processor.ts
@@ -1,14 +1,14 @@
 import Application from "../application";
 import Resource from "../resource";
 import { Operation, ResourceConstructor } from "../types";
-import { classify, singularize } from "../utils/string";
+import { camelize, singularize } from "../utils/string";
 
 export default class OperationProcessor<ResourceT = Resource> {
   public app: Application;
   public resourceClass?: ResourceConstructor;
 
   shouldHandle(op: Operation) {
-    return this.resourceClass && op.ref.type === this.resourceClass.name;
+    return this.resourceClass && op.ref.type === this.resourceClass.type;
   }
 
   execute(op: Operation): Promise<ResourceT | ResourceT[] | void> {
@@ -16,9 +16,9 @@ export default class OperationProcessor<ResourceT = Resource> {
     return this[action] && this[action].call(this, op);
   }
 
-  resourceFor(type: string = ""): ResourceConstructor {
-    return this.app.types.find(({ name }: { name: string }) => {
-      return name === classify(singularize(type));
+  resourceFor(resourceType: string = ""): ResourceConstructor {
+    return this.app.types.find(({ type }: { type: string }) => {
+      return type === camelize(singularize(resourceType));
     });
   }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -2,10 +2,14 @@ import { ResourceTypeAttributes, ResourceTypeRelationships } from "./types";
 import { camelize } from "./utils/string";
 
 export default abstract class Resource {
-  public type: string;
-  public id?: string;
-  public attributes: ResourceTypeAttributes;
-  public relationships: ResourceTypeRelationships;
+  id?: string;
+  type: string;
+  attributes: ResourceTypeAttributes;
+  relationships: ResourceTypeRelationships;
+
+  static get type() {
+    return camelize(this.name);
+  }
 
   constructor({
     id,
@@ -16,9 +20,8 @@ export default abstract class Resource {
     attributes?: ResourceTypeAttributes;
     relationships?: ResourceTypeRelationships;
   }) {
-    this.type = camelize(this.constructor.name);
-
     this.id = id;
+    this.type = (this.constructor as typeof Resource).type;
     this.attributes = attributes || {};
     this.relationships = relationships || {};
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,8 @@ export type OperationResponse = {
 };
 
 export type ResourceConstructor<ResourceT = Resource> = {
+  type: string;
+
   new ({
     id,
     attributes,

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,10 +1,13 @@
-export { plural as pluralize, singular as singularize } from "pluralize";
+import { plural, singular } from "pluralize";
 
-export {
-  decamelize,
-  dasherize,
-  camelize,
-  classify,
-  underscore,
-  capitalize
-} from "ember-cli-string-utils";
+function pluralize(word = "") {
+  return plural(word);
+}
+
+function singularize(word = "") {
+  return singular(word);
+}
+
+export { camelize, capitalize, classify, dasherize, decamelize, underscore } from "ember-cli-string-utils";
+export { pluralize, singularize };
+


### PR DESCRIPTION
Now we can define custom resource type, eg:
```js
import { Resource } from "../../jsonapi-ts";

export default class User extends Resource {
  static get type() {
    return 'myUser';
  }
}
```