### PR TITLE
Use processor shouldHandle

### DIFF
--- a/src/processors/operation-processor.ts
+++ b/src/processors/operation-processor.ts
@@ -7,7 +7,7 @@ export default class OperationProcessor<ResourceT = Resource> {
   public app: Application;
   public resourceClass?: ResourceConstructor;
 
-  shouldHandle(op: Operation) {
+  async shouldHandle(op: Operation): Promise<boolean> {
     return this.resourceClass && op.ref.type === this.resourceClass.type;
   }
 


### PR DESCRIPTION
We will use processor#shouldHandle method to determine if an operation can be handled or not.

### Example:
If there will be a processor called `customProcessor` which overrides `shouldHandle`:
```js
  async shouldHandle(op: Operation): Promise<boolean> {
    return op.ref.type === "customResource"
  }
```

That would mean that every operation with type `customResource` will go through this processor.

If the type will be eg: `user` and there will be no any extra processor,  the operation will be handled by `dafaultProcessor` if there is a resource with type `user`. Otherwise, we will return 404 as this operation is not supported by our server.