### PR TITLE
Adds user attribute check for @Authorize

### DIFF
--- a/src/decorators/authorize.ts
+++ b/src/decorators/authorize.ts
@@ -1,11 +1,20 @@
 import JsonApiErrors from "../json-api-errors";
+import { AttributeValueMatch } from "../types";
 
 import decorateWith from "./decorator";
 
 function authorizeMiddleware(operation: Function) {
-  return function() {
+  return function(...conditions: AttributeValueMatch[]) {
     if (!this.app.user) {
       throw JsonApiErrors.Unauthorized();
+    }
+
+    if (
+      !conditions.every(
+        ({ attribute, value }) => this.app.user[attribute] === value
+      )
+    ) {
+      throw JsonApiErrors.AccessDenied();
     }
 
     return operation.call(this, ...arguments);
@@ -17,6 +26,6 @@ function authorizeMiddleware(operation: Function) {
  * context object. If there is, it'll allow the operation to continue.
  * If not, it'll throw an `Unauthorized` error code.
  */
-export default function authorize() {
-  return decorateWith(authorizeMiddleware);
+export default function authorize(...conditions: AttributeValueMatch[]) {
+  return decorateWith(authorizeMiddleware, conditions);
 }

--- a/src/decorators/if-user.ts
+++ b/src/decorators/if-user.ts
@@ -1,0 +1,6 @@
+export default function ifEquals(
+  attribute: string,
+  value: string | number | boolean
+) {
+  return { attribute, value };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Application from "./application";
 import Authorize from "./decorators/authorize";
 import decorateWith from "./decorators/decorator";
+import IfUser from "./decorators/if-user";
 import JsonApiErrors from "./json-api-errors";
 import jsonApiKoa from "./middlewares/json-api-koa";
 import KnexProcessor from "./processors/knex-processor";
@@ -17,7 +18,8 @@ export {
   OperationProcessor,
   // Decorators API
   decorateWith,
-  Authorize
+  Authorize,
+  IfUser
 };
 
 export * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,3 +115,8 @@ export type KnexRecord = {
   id: string;
   [key: string]: any;
 };
+
+export type AttributeValueMatch = {
+  attribute: string;
+  value: string | number | boolean;
+};


### PR DESCRIPTION
This allows to add conditions to the `@Authorize` decorator by checking attribute values on the User model.

**Example usage**
```ts
import {
  KnexProcessor,
  Authorize,
  IfUser
} from "jsonapi-ts";

export default class BookProcessor extends KnexProcessor {
  @Authorize(IfUser("role", "admin"))
  public async add(op: Operation): Promise<any> {
    return super.add(op);
  }
}
```