### PR TITLE
Supports filtering by NULL, NOT NULL

### DIFF
--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -24,6 +24,20 @@ const getOperator = (paramValue: string): string =>
     )
   ];
 
+const getWhereMethod = (value: string, operator: string) => {
+  if (value !== "null") {
+    return "andWhere";
+  }
+
+  if (value === "null" && operator === "=") {
+    return "whereNull";
+  }
+
+  if (value === "null" && operator === "!=") {
+    return "whereNotNull";
+  }
+};
+
 const buildSortClause = (sort: string[]) =>
   sort.map(criteria => {
     if (criteria.startsWith("-")) {
@@ -177,17 +191,16 @@ export default class KnexProcessor<
         value = value.substring(value.indexOf(":") + 1);
       }
 
-      value = value !== "null" ? value : 0;
-
       processedFilters.push({
         value,
         operator,
+        method: getWhereMethod(value, operator),
         column: camelize(key)
       });
     });
 
     return processedFilters.forEach(filter => {
-      return queryBuilder.andWhere(
+      return queryBuilder[filter.method](
         filter.column,
         filter.operator,
         filter.value


### PR DESCRIPTION
This PR modifies the way `queryBuilder` creates the `WHERE` clause by defining which `Knex` method is more suited to the requested filter.

## How does this work?

Let's assume an API operation requests to do:

```
/books?filter[category]=null
```

**If the operator is `eq` (=) and the filter value is `null`, `filtersToKnex` will use `whereNull`:**

```ts
queryBuilder.whereNull("category");
```

What happens if the filter is negated?

```
/books?filter[category]=ne:null
```

**If the operator is `ne` (!=) and the filter value is `null`, `filtersToKnex` will use `whereNotNull`:**

```ts
queryBuilder.whereNotNull("category");
```

**For every other case, it'll use `andWhere`.**

## But... the signatures don't match.

Yes, `andWhere()` takes 3 arguments and `whereNull` / `whereNotNull` just one. **It doesn't matter.** All of these functions start with `column` as first argument, so there's no need to add code to discern which signature is required.

## Something else?
Oh, yeah. This... Fixes #53.