### PR TITLE
Fix response to requests without include filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebryn/jsonapi-ts",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/application.ts
+++ b/src/application.ts
@@ -99,17 +99,51 @@ export default class Application {
 
 
     return included.length ?
-      { included: uniqueIncluded, data: this.serializeResources(data) } :
-      { data: this.serializeResources(data) };
+      { included: uniqueIncluded, data: await this.serializeResources(data) } :
+      { data: await this.serializeResources(data) };
   }
 
-  serializeResources(data: Resource | Resource[] | void) {
+  async serializeResources(data: Resource | Resource[] | void) {
     if (!data) {
       return null;
     }
 
     if (Array.isArray(data)) {
-      return data.map(record => this.serializeResources(record));
+      return Promise.all(data.map(record => this.serializeResources(record)));
+    }
+
+    if (!Object.entries(data.relationships).length) {
+      const schemaRelationships = (await this.resourceFor(data.type)).schema.relationships;
+      const relationshipsFound = Object.keys(schemaRelationships)
+        .filter(relName => schemaRelationships[relName].belongsTo)
+        .filter(
+          relName =>
+            data.attributes[
+            schemaRelationships[relName].foreignKeyName ||
+            `${schemaRelationships[relName]}Id`
+            ]
+        )
+        .map(
+          relationshipName => ({
+            name: relationshipName,
+            key:
+              schemaRelationships[relationshipName].foreignKeyName ||
+              `${schemaRelationships[relationshipName]}Id`
+          }));
+
+      data.relationships = relationshipsFound
+        .reduce((relationships, relationship) => ({
+          ...relationships,
+          [relationship.name]: {
+            id: data.attributes[relationship.key],
+            type: schemaRelationships[relationship.name].type().type
+          }
+        }), {});
+
+      data.attributes = unpick(
+        data.attributes,
+        relationshipsFound.map(relationship => relationship.key)
+      );
     }
 
     Object.keys(data.relationships).forEach(relationshipName => {

--- a/src/application.ts
+++ b/src/application.ts
@@ -113,7 +113,10 @@ export default class Application {
     }
 
     if (!Object.entries(data.relationships).length) {
-      const schemaRelationships = (await this.resourceFor(data.type)).schema.relationships;
+
+      const resourceSchema = (await this.resourceFor(data.type)).schema;
+      const schemaRelationships = resourceSchema.relationships;
+
       const relationshipsFound = Object.keys(schemaRelationships)
         .filter(relName => schemaRelationships[relName].belongsTo)
         .filter(
@@ -142,7 +145,11 @@ export default class Application {
 
       data.attributes = unpick(
         data.attributes,
-        relationshipsFound.map(relationship => relationship.key)
+        relationshipsFound
+          .map(relationship => relationship.key)
+          .filter(relationshipKey =>
+            !Object.keys(resourceSchema.attributes).includes(relationshipKey)
+          )
       );
     }
 

--- a/src/processors/operation-processor.ts
+++ b/src/processors/operation-processor.ts
@@ -61,19 +61,9 @@ export default class OperationProcessor<ResourceT extends Resource> {
     record: HasId,
     eagerLoadedData: EagerLoadedData
   ) {
-    const relationshipKeys = Object.keys(resourceClass.schema.relationships)
-      .filter(relName => resourceClass.schema.relationships[relName].belongsTo)
-      .map(
-        relationshipName =>
-          resourceClass.schema.relationships[relationshipName].foreignKeyName ||
-          `${resourceClass.schema.relationships[relationshipName]}Id`
-      );
-    const schemaKeys = !op.params.include
-      ? Object.keys(resourceClass.schema.attributes).concat(relationshipKeys)
-      : Object.keys(resourceClass.schema.attributes);
-
     const attributeKeys =
-      (op.params.fields && op.params.fields[resourceClass.type]) || schemaKeys;
+      (op.params.fields && op.params.fields[resourceClass.type]) ||
+      Object.keys(resourceClass.schema.attributes);
     return pick(record, attributeKeys);
   }
 
@@ -87,6 +77,26 @@ export default class OperationProcessor<ResourceT extends Resource> {
     return promiseHashMap(relationships, key => {
       return relationships[key].call(this, record);
     });
+  }
+
+  async getRelationshipAttributes(
+    op: Operation,
+    resourceClass: typeof Resource,
+    record: HasId,
+    eagerLoadedData: EagerLoadedData
+  ) {
+    if (op.params.include) {
+      return {};
+    }
+
+    const relationshipKeys = Object.keys(resourceClass.schema.relationships)
+      .filter(relName => resourceClass.schema.relationships[relName].belongsTo)
+      .map(
+        relationshipName =>
+          resourceClass.schema.relationships[relationshipName].foreignKeyName ||
+          `${resourceClass.schema.relationships[relationshipName]}Id`
+      );
+    return pick(record, relationshipKeys);
   }
 
   async convertToResources(
@@ -104,11 +114,16 @@ export default class OperationProcessor<ResourceT extends Resource> {
 
     const record = { ...records };
     const resourceClass = await this.resourceFor(op.ref.type);
-
-    const [attributes, computedAttributes, relationships] = await Promise.all([
+    const [
+      attributes,
+      computedAttributes,
+      relationships,
+      relationshipAttributes
+    ] = await Promise.all([
       this.getAttributes(op, resourceClass, record, eagerLoadedData),
       this.getComputedProperties(op, resourceClass, record, eagerLoadedData),
-      this.getRelationships(op, record, eagerLoadedData)
+      this.getRelationships(op, record, eagerLoadedData),
+      this.getRelationshipAttributes(op, resourceClass, record, eagerLoadedData)
     ]);
 
     return new resourceClass({
@@ -116,6 +131,7 @@ export default class OperationProcessor<ResourceT extends Resource> {
       id: record.id,
       attributes: {
         ...attributes,
+        ...relationshipAttributes,
         ...computedAttributes
       }
     });


### PR DESCRIPTION
This PR transforms the response to requests of models with belongsTo relationships, to comply more with the JSONAPI specs.

Currently, hitting the API with a GET to the `/comments` url will respond with this:
``` 
{
   "data": [
        {
           "id": 1,
           "type": "comment",
           "attributes": {
                 "body": "bodybody3"
           },
        },
   ...
   ]
}
```
and the only way to see the attribute author_id is by adding it to the attributes list, and that results in:

``` 
{
   "data": [
        {
           "id": 1,
           "type": "comment",
           "attributes": {
                 "body": "bodybody3",
                 "author_id": 1
           },
        },
   ...
   ]
}
```
which is not JSONAPI compliant.
So, by passing through the relationship keys at the knexProcessor level, and then serializing them at the application level, that same request gets this response:
``` 
{
   "data": [
        {
           "id": 1,
           "type": "comment",
           "attributes": {
                 "body": "bodybody3"
           },
            "relationships": {
                "author": {
                    "id": 1,
                    "type": "user"
                }
            }
        },
   ...
   ]
}
```

To ensure that chameleon doesn't break horribly because of this (I'm aware that chameleon has no relationships defined, and the relationship keys are loaded as attributes) , I added the possibility of not removing the properties from the attributes, if it's loaded in the attributes list.