### PR TITLE
adds resource deserializer to requests

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -58,24 +58,27 @@ export default class Application {
   }
 
   async deserializeResource(op: Operation) {
+    if (!op.data || !op.data.attributes) {
+      return op;
+    }
+
     const resourceClass = await this.resourceFor(op.ref.type);
     const schemaRelationships = resourceClass.schema.relationships;
-    if (op.data && op.data.attributes) {
-      op.data.attributes = Object.keys(schemaRelationships)
-        .filter(
-          relName =>
-            schemaRelationships[relName].belongsTo &&
-            op.data.relationships.hasOwnProperty(relName)
-        )
-        .reduce(
-          (relationAttributes, relName) => ({
-            ...relationAttributes,
-            [schemaRelationships[relName].foreignKeyName || `${schemaRelationships[relName].type().type}Id`]:
-              (<ResourceRelationshipData>op.data.relationships[relName].data).id
-          }),
-          op.data.attributes
-        );
-    }
+    op.data.attributes = Object.keys(schemaRelationships)
+      .filter(
+        relName =>
+          schemaRelationships[relName].belongsTo &&
+          op.data.relationships.hasOwnProperty(relName)
+      )
+      .reduce(
+        (relationAttributes, relName) => ({
+          ...relationAttributes,
+          [schemaRelationships[relName].foreignKeyName || `${schemaRelationships[relName].type().type}Id`]:
+            (<ResourceRelationshipData>op.data.relationships[relName].data).id
+        }),
+        op.data.attributes
+      );
+
     return op;
   }
 


### PR DESCRIPTION
closes #86
This PR adds de-serialization to requests, to read **relationship** objects passed. This is done by transforming the objects passed in the request into the FK of the resource to be added/updated in the database.

Basically, previous to this PR, any **POST** or **PATCH** that had this payload in the request, ignored the specified relationships
```
{
    "data": {
        "type": "user",
        "attributes": {
            "email": "flyster91@prototypal.io"
        },
        "relationships": {                                             // ignored
        	"articles":{                                           // ignored
        		"data":{                                       // ignored
        			"id": 2,                               // ignored
        			"type":"article"                       // ignored
        		}                                              // ignored
        	}                                                      // ignored
        }                                                              // ignored
    }
}
```
-----------
## Warning
For now, this PR limits it's scope to belongsTo relationships, as hasMany relationships is a much more complex endeavor (as one add operation could involve multiple update or create, or even delete operations), and requires further analysis.