### PR TITLE
support requests with no relationships attribute

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -72,6 +72,7 @@ export default class Application {
       .filter(
         relName =>
           schemaRelationships[relName].belongsTo &&
+          op.data.relationships &&
           op.data.relationships.hasOwnProperty(relName)
       )
       .reduce((relationAttributes, relName) => {


### PR DESCRIPTION
Quick fix to support requests where the relationships object is not provided. 
This bug currently affects login in Chameleon