### PR TITLE
Adds support for WebSocket authentication

### DIFF
--- a/src/json-api-errors.ts
+++ b/src/json-api-errors.ts
@@ -23,6 +23,11 @@ const jsonApiErrors: {
   RecordNotExists: (): JsonApiError => ({
     status: HttpStatusCode.NotFound,
     code: "not_found"
+  }),
+
+  InvalidToken: (): JsonApiError => ({
+    status: HttpStatusCode.UnprocessableEntity,
+    code: "invalid_token"
   })
 };
 

--- a/src/middlewares/json-api-websocket.ts
+++ b/src/middlewares/json-api-websocket.ts
@@ -1,26 +1,48 @@
 import { Server } from "ws";
+
 import Application from "../application";
 import { JsonApiDocument } from "../types";
+import ApplicationInstance from "../application-instance";
 
 export default function jsonApiWebSocket(
   websocketServer: Server,
   app: Application
 ) {
   websocketServer.on("connection", connection => {
-    connection.on("message", async message => {
-      if (!message) {
-        return;
+    connection.on("message", async (message: Buffer) => {
+      try {
+        const appInstance = new ApplicationInstance(app);
+
+        if (!message) {
+          return;
+        }
+
+        const { meta, operations } = JSON.parse(
+          message.toString()
+        ) as JsonApiDocument;
+
+        // Get user.
+        if (meta && meta.token) {
+          appInstance.user = await appInstance.getUserFromToken(
+            meta.token as string
+          );
+        }
+
+        // Execute and reply.
+        const response = await appInstance.app.executeOperations(operations);
+
+        connection.send(
+          JSON.stringify({
+            operations: response
+          })
+        );
+      } catch (e) {
+        connection.send(
+          JSON.stringify({
+            errors: [e]
+          })
+        );
       }
-
-      const { operations } = JSON.parse(message.toString()) as JsonApiDocument;
-
-      const response = await app.executeOperations(operations);
-
-      connection.send(
-        JSON.stringify({
-          operations: response
-        })
-      );
     });
   });
 }


### PR DESCRIPTION
Contributes to #99.

Allows to send a JWT on the `meta.token` property, used to detect the requesting user. Also unifies the get-user-from-token logic into a single utility function in ApplicationInstance.