### PR TITLE
Fixed bad token serialization and prevents password leaking in JWT

### DIFF
--- a/tests/dummy/src/app.ts
+++ b/tests/dummy/src/app.ts
@@ -1,5 +1,5 @@
 import * as Knex from "knex";
-import { Application, KnexProcessor, Operation, SessionProcessor, Session, ResourceAttributes } from "./jsonapi-ts";
+import { Application, KnexProcessor, Operation, ResourceAttributes } from "./jsonapi-ts";
 import ArticleProcessor from "./processors/article";
 import Article from "./resources/article";
 import User from "./resources/user";
@@ -9,6 +9,8 @@ import VoteProcessor from "./processors/vote";
 import hash from "./utils/hash";
 import UserProcessor from "./processors/user";
 import knexfile from "./knexfile";
+import Session from "./resources/session";
+import SessionProcessor from "./processors/session";
 
 const knexConfig = knexfile[process.env.NODE_ENV || "development"];
 

--- a/tests/dummy/src/processors/session.ts
+++ b/tests/dummy/src/processors/session.ts
@@ -1,45 +1,6 @@
-import { KnexProcessor, Operation, JsonApiErrors, HasId } from "../jsonapi-ts";
-import { sign } from "jsonwebtoken";
-import Session from "../resources/Session";
-import { v4 as uuid } from "uuid";
+import { SessionProcessor as JsonApiSessionProcessor } from "../jsonapi-ts";
+import Session from "../resources/session";
 
-export default class SessionProcessor<ResourceT extends Session> extends KnexProcessor<ResourceT> {
+export default class SessionProcessor<ResourceT extends Session> extends JsonApiSessionProcessor<ResourceT> {
   public static resourceClass = Session;
-
-  public async add(op: Operation): Promise<HasId> {
-    const userFromDB = await this.knex("users")
-      .where({ email: op.data.attributes.email })
-      .first();
-
-    const isLoggedIn = userFromDB && userFromDB.password === op.data.attributes.password;
-
-    if (!isLoggedIn) {
-      throw JsonApiErrors.AccessDenied();
-    }
-
-    const { id, password, ...publicUser } = userFromDB;
-
-    const token = sign(
-      {
-        id,
-        type: "user",
-        attributes: {
-          ...publicUser
-        }
-      },
-      "session_key_test",
-      {
-        subject: String(id),
-        expiresIn: "1d"
-      }
-    );
-
-    const session = {
-      token,
-      id: uuid(),
-      user_id: userFromDB.id
-    };
-
-    return session;
-  }
 }

--- a/tests/dummy/src/resources/session.ts
+++ b/tests/dummy/src/resources/session.ts
@@ -1,0 +1,22 @@
+import { Resource, Password } from "../jsonapi-ts";
+import User from "./user";
+
+export default class Session extends Resource {
+  public static get type() {
+    return "session";
+  }
+
+  public static schema = {
+    attributes: {
+      token: String,
+      username: String,
+      password: Password
+    },
+    relationships: {
+      user: {
+        type: () => User,
+        belongsTo: true
+      }
+    }
+  };
+}


### PR DESCRIPTION
The built-in SessionProcessor was not serializing the `User` model before JWT'ing it, and it was also not removing sensitive data fields such as Password-type data.