### PR TITLE
fix & refactor: empty/not-found responses

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -75,7 +75,9 @@ export default class Application {
   }
 
   async executeOperation(op: Operation, processor: OperationProcessor<Resource>): Promise<OperationResponse> {
-    const result = await processor.execute(await this.deserializeResource(op));
+    const resourceClass = await this.resourceFor(op.ref.type);
+    const deserializedOperation = await this.serializer.deserializeResource(op, resourceClass);
+    const result = await processor.execute(deserializedOperation);
     return this.buildOperationResponse(result);
   }
 
@@ -92,34 +94,7 @@ export default class Application {
       })
     );
   }
-  // TODO: test create/update resources
-  async deserializeResource(op: Operation) {
-    if (!op.data || !op.data.attributes) {
-      return op;
-    }
 
-    const resourceClass = await this.resourceFor(op.ref.type);
-    const primaryKey = resourceClass.schema.primaryKeyName || DEFAULT_PRIMARY_KEY;
-    const schemaRelationships = resourceClass.schema.relationships;
-    op.data.attributes = Object.keys(schemaRelationships)
-      .filter(
-        relName =>
-          schemaRelationships[relName].belongsTo &&
-          op.data.relationships &&
-          op.data.relationships.hasOwnProperty(relName)
-      )
-      .reduce((relationAttributes, relName) => {
-        const key =
-          schemaRelationships[relName].foreignKeyName || this.serializer.relationshipToColumn(relName, primaryKey);
-        const value = (<ResourceRelationshipData>op.data.relationships[relName].data).id;
-
-        return {
-          ...relationAttributes,
-          [key]: value
-        };
-      }, op.data.attributes);
-    return op;
-  }
 
   async processorFor(
     resourceType: string,
@@ -161,8 +136,11 @@ export default class Application {
   }
 
   async serializeResources(data: Resource | Resource[] | void) {
-    if (!data || (Array.isArray(data) && !data.length)) {
+    if (!data) {
       return null;
+    }
+    if (Array.isArray(data) && !data.length) {
+      return [];
     }
 
     const dataArrayed = Array.isArray(data) ? data : [data];

--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -110,6 +110,10 @@ export default class KnexProcessor<ResourceT extends Resource> extends Operation
       .modify(queryBuilder => this.optionsBuilder(queryBuilder, op))
       .select(getColumns(this.resourceClass, this.appInstance.app.serializer, op.params.fields));
 
+    if (!records.length && id) {
+      throw JsonApiErrors.RecordNotExists();
+    }
+
     return records;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,12 +133,12 @@ export type PasswordConstructor = typeof Password;
 
 export type ResourceSchemaAttributes = {
   [key: string]:
-    | StringConstructor
-    | NumberConstructor
-    | BooleanConstructor
-    | ArrayConstructor
-    | ObjectConstructor
-    | PasswordConstructor;
+  | StringConstructor
+  | NumberConstructor
+  | BooleanConstructor
+  | ArrayConstructor
+  | ObjectConstructor
+  | PasswordConstructor;
 };
 
 export type ResourceSchemaRelationships = {
@@ -172,6 +172,7 @@ export interface IJsonApiSerializer {
   relationshipToColumn(relationshipName: string, primaryKeyName: string): string;
   columnToRelationship(columnName: string, primaryKeyName: string): string;
   foreignResourceToForeignTableName(foreignResourceType: string, prefix?: string): string;
+  deserializeResource(op: Operation, resourceClass: typeof Resource): Operation;
   serializeResource(resource: Resource, resourceType: typeof Resource): Resource;
   serializeRelationship(relationships: Resource | Resource[], primaryKeyName?: string): ResourceRelationshipData[];
 }


### PR DESCRIPTION
This PR does two things:
- Moves the _deserializeResource_ function to the serialiser class (to lighten up the application class).
- Changes the response of jsonapi when a specific resource is not found (before it showed a `data:null`, now it throws a `404 error`)
- Changes the response when a search produces no results, from `data:null` to `data:[]`

closes #116 and closes #132 