### PR TITLE
Allow DB to take control of ID generation for users

### DIFF
--- a/src/addons/user-management.ts
+++ b/src/addons/user-management.ts
@@ -19,7 +19,6 @@ export type UserManagementAddonOptions = AddonOptions & {
 
 const defaults: UserManagementAddonOptions = {
   userResource: User,
-  userGenerateIdCallback: async () => Date.now().toString(),
   userLoginCallback: async () => {
     console.warn(
       "WARNING: You're using the default login callback with UserManagementAddon." +
@@ -59,7 +58,7 @@ export default class UserManagementAddon extends Addon {
         public static resourceClass = options.userResource;
 
         protected async generateId() {
-          return options.userGenerateIdCallback();
+          return (options.userGenerateIdCallback || (async () => undefined))();
         }
 
         protected async encryptPassword(op: Operation) {

--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -8,7 +8,7 @@ import {
   ResourceSchemaRelationship,
   EagerLoadedData,
   DEFAULT_PRIMARY_KEY,
-  IJsonApiSerializer,
+  IJsonApiSerializer
 } from "../types";
 import pick from "../utils/pick";
 import promiseHashMap from "../utils/promise-hash-map";
@@ -170,6 +170,10 @@ export default class KnexProcessor<ResourceT extends Resource> extends Operation
         [this.appInstance.app.serializer.attributeToColumn(attribute)]: op.data.attributes[attribute]
       }))
       .reduce((keyValues, keyValue) => ({ ...keyValues, ...keyValue }), {});
+
+    if (op.data.id) {
+      dataToInsert[primaryKeyName] = op.data.id;
+    }
 
     const ids = await this.getQuery().insert(dataToInsert, primaryKeyName);
 

--- a/src/processors/user-processor.ts
+++ b/src/processors/user-processor.ts
@@ -11,8 +11,8 @@ export default class UserProcessor<T extends User> extends KnexProcessor<T> {
     return super.get({ ...op, params: {} });
   }
 
-  protected async generateId(): Promise<any> { }
-  protected async encryptPassword(op: Operation): Promise<any> { }
+  protected async generateId(): Promise<any> {}
+  protected async encryptPassword(op: Operation): Promise<any> {}
 
   async add(op: Operation): Promise<HasId> {
     const fields = Object.keys(op.data.attributes)
@@ -23,23 +23,14 @@ export default class UserProcessor<T extends User> extends KnexProcessor<T> {
     const id = await this.generateId();
 
     const encryptedPassword = await this.encryptPassword(op);
-    const tableName = this.appInstance.app.serializer.resourceTypeToTableName(this.resourceClass.type);
 
-    await this.knex(tableName).insert({
+    op.data.attributes = {
       ...fields,
-      ...encryptedPassword,
-      id
-    });
+      ...encryptedPassword
+    };
+    op.data.id = id;
 
-    const user = await this.knex(tableName)
-      .where({ id })
-      .select(
-        this.resourceClass.schema.primaryKeyName || DEFAULT_PRIMARY_KEY,
-        ...Object.keys(fields).map(attribute => this.appInstance.app.serializer.attributeToColumn(attribute))
-      )
-      .first();
-
-    return user;
+    return super.add(op);
   }
 
   @Authorize()

--- a/tests/dummy/src/app.ts
+++ b/tests/dummy/src/app.ts
@@ -15,13 +15,14 @@ const knexConfig = knexfile[process.env.NODE_ENV || "development"];
 
 const app = new Application({
   namespace: "api",
-  types: [User, Article, Comment, Vote],
+  types: [Article, Comment, Vote],
   processors: [ArticleProcessor, VoteProcessor],
   defaultProcessor: KnexProcessor
 });
 
 app.use(UserManagementAddon, {
   userResource: User,
+  // userGenerateIdCallback: async () => (-Date.now()).toString(),
   userLoginCallback: login,
   userEncryptPasswordCallback: encryptPassword
 } as UserManagementAddonOptions);


### PR DESCRIPTION
This PR disables the Date.now()-based fallback for ID generation for new user records. If no ID generator is supplied, it'll skip using the `id` field as part of the `INSERT`.

Also, makes the KnexProcessor `data.id`-aware so if an ID is supplied, it can use it for the database.