### PR TITLE
Allows the UserManagementAddon to accept a custom UserProcessor

### DIFF
--- a/src/addons/user-management.ts
+++ b/src/addons/user-management.ts
@@ -10,6 +10,7 @@ import Session from "../resources/session";
 
 export type UserManagementAddonOptions = AddonOptions & {
   userResource: typeof User;
+  userProcessor?: typeof JsonApiUserProcessor;
   userEncryptPasswordCallback?: (op: Operation) => Promise<ResourceAttributes>;
   userLoginCallback?: (op: Operation, userDataSource: ResourceAttributes) => Promise<boolean>;
   userGenerateIdCallback?: () => Promise<string>;
@@ -19,6 +20,7 @@ export type UserManagementAddonOptions = AddonOptions & {
 
 const defaults: UserManagementAddonOptions = {
   userResource: User,
+  userProcessor: JsonApiUserProcessor,
   userLoginCallback: async () => {
     console.warn(
       "WARNING: You're using the default login callback with UserManagementAddon." +
@@ -54,7 +56,7 @@ export default class UserManagementAddon extends Addon {
 
   private createUserProcessor() {
     return (options =>
-      class UserProcessor<T extends User> extends JsonApiUserProcessor<T> {
+      class UserProcessor<T extends User> extends options.userProcessor<T> {
         public static resourceClass = options.userResource;
 
         protected async generateId() {

--- a/src/processors/user-processor.ts
+++ b/src/processors/user-processor.ts
@@ -12,7 +12,9 @@ export default class UserProcessor<T extends User> extends KnexProcessor<T> {
   }
 
   protected async generateId(): Promise<any> {}
-  protected async encryptPassword(op: Operation): Promise<any> {}
+  protected async encryptPassword(op: Operation): Promise<any> {
+    throw new Error("You must implement a password encryption mechanism.");
+  }
 
   async add(op: Operation): Promise<HasId> {
     const fields = Object.keys(op.data.attributes)

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,12 +134,12 @@ export type PasswordConstructor = typeof Password;
 
 export type ResourceSchemaAttributes = {
   [key: string]:
-  | StringConstructor
-  | NumberConstructor
-  | BooleanConstructor
-  | ArrayConstructor
-  | ObjectConstructor
-  | PasswordConstructor;
+    | StringConstructor
+    | NumberConstructor
+    | BooleanConstructor
+    | ArrayConstructor
+    | ObjectConstructor
+    | PasswordConstructor;
 };
 
 export type ResourceSchemaRelationships = {
@@ -162,8 +162,6 @@ export type EagerLoadedData = { [key: string]: KnexRecord[] | undefined };
 
 export type ApplicationServices = {
   knex?: Knex;
-  login?: (op: Operation, userDataSource: ResourceAttributes) => Promise<boolean>;
-  password?: (op: Operation) => Promise<ResourceAttributes>;
 } & { [key: string]: any };
 
 export interface IJsonApiSerializer {

--- a/tests/dummy/src/app.ts
+++ b/tests/dummy/src/app.ts
@@ -10,6 +10,7 @@ import knexfile from "./knexfile";
 
 import login from "./callbacks/login";
 import encryptPassword from "./callbacks/encrypt-password";
+import MyVeryOwnUserProcessor from "./processors/user";
 
 const knexConfig = knexfile[process.env.NODE_ENV || "development"];
 
@@ -22,9 +23,10 @@ const app = new Application({
 
 app.use(UserManagementAddon, {
   userResource: User,
+  userProcessor: MyVeryOwnUserProcessor,
+  userLoginCallback: login
   // userGenerateIdCallback: async () => (-Date.now()).toString(),
-  userLoginCallback: login,
-  userEncryptPasswordCallback: encryptPassword
+  // userEncryptPasswordCallback: encryptPassword
 } as UserManagementAddonOptions);
 
 app.services.knex = Knex(knexConfig);

--- a/tests/dummy/src/processors/user.ts
+++ b/tests/dummy/src/processors/user.ts
@@ -1,0 +1,13 @@
+import { UserProcessor, Operation } from "../jsonapi-ts";
+import User from "../resources/user";
+import encryptPassword from "../callbacks/encrypt-password";
+
+export default class MyVeryOwnUserProcessor<T extends User> extends UserProcessor<T> {
+  protected async generateId() {
+    return `${101}${Date.now()}`;
+  }
+
+  protected async encryptPassword(op: Operation) {
+    return encryptPassword(op);
+  }
+}


### PR DESCRIPTION
Merge after #145.

This allows the app to implement any feature it needs into the UserProcessor. The UserManagementAddon will use the `generateId` and `encryptPassword` functions as follows:

- If the app provides `userProcessor`, the `generateId` (if available) and `encryptPassword` functions will be executed from the class.

- If the app doesn't sets `UserProcessor`,  the `generateId` (if available) and `encryptPassword` functions will be executed from the `options` hash.