### PR TITLE
fix: sets the user relationship FK name

### DIFF
--- a/src/addons/user-management.ts
+++ b/src/addons/user-management.ts
@@ -24,7 +24,7 @@ const defaults: UserManagementAddonOptions = {
   userLoginCallback: async () => {
     console.warn(
       "WARNING: You're using the default login callback with UserManagementAddon." +
-        "ANY LOGIN REQUEST WILL PASS. Implement this callback in your addon configuration."
+      "ANY LOGIN REQUEST WILL PASS. Implement this callback in your addon configuration."
     );
     return true;
   },
@@ -32,7 +32,7 @@ const defaults: UserManagementAddonOptions = {
   userEncryptPasswordCallback: async (op: Operation) => {
     console.warn(
       "WARNING: You're using the default encryptPassword callback with UserManagementAddon." +
-        "Your password is NOT being encrypted. Implement this callback in your addon configuration."
+      "Your password is NOT being encrypted. Implement this callback in your addon configuration."
     );
 
     return { password: op.data.attributes.password };
@@ -109,7 +109,8 @@ export default class UserManagementAddon extends Addon {
           relationships: {
             user: {
               type: () => options.userResource,
-              belongsTo: true
+              belongsTo: true,
+              foreignKeyName: "user_id"
             }
           }
         };

--- a/src/addons/user-management.ts
+++ b/src/addons/user-management.ts
@@ -109,8 +109,7 @@ export default class UserManagementAddon extends Addon {
           relationships: {
             user: {
               type: () => options.userResource,
-              belongsTo: true,
-              foreignKeyName: "user_id"
+              belongsTo: true
             }
           }
         };

--- a/src/processors/session-processor.ts
+++ b/src/processors/session-processor.ts
@@ -13,7 +13,7 @@ export default class SessionProcessor<T extends Session> extends KnexProcessor<T
   protected async login(op: Operation, userDataSource: ResourceAttributes) {
     console.warn(
       "WARNING: You're using the default login callback with UserManagementAddon." +
-        "ANY LOGIN REQUEST WILL PASS. Implement this callback in your addon configuration."
+      "ANY LOGIN REQUEST WILL PASS. Implement this callback in your addon configuration."
     );
     return true;
   }
@@ -71,8 +71,8 @@ export default class SessionProcessor<T extends Session> extends KnexProcessor<T
 
     const session = {
       token,
-      [this.appInstance.app.serializer.attributeToColumn(
-        `${userType.type}_${userType.schema.primaryKeyName || DEFAULT_PRIMARY_KEY}`
+      [this.appInstance.app.serializer.relationshipToColumn(
+        userType.type, userType.schema.primaryKeyName
       )]: userId,
       id: randomBytes(16).toString("hex")
     };

--- a/src/resources/session.ts
+++ b/src/resources/session.ts
@@ -16,7 +16,8 @@ export default class Session extends Resource {
     relationships: {
       user: {
         type: () => User,
-        belongsTo: true
+        belongsTo: true,
+        foreignKeyName: "user_id"
       }
     }
   };

--- a/src/resources/session.ts
+++ b/src/resources/session.ts
@@ -16,7 +16,7 @@ export default class Session extends Resource {
     relationships: {
       user: {
         type: () => User,
-        belongsTo: true,
+        belongsTo: true
       }
     }
   };

--- a/src/resources/session.ts
+++ b/src/resources/session.ts
@@ -17,7 +17,6 @@ export default class Session extends Resource {
       user: {
         type: () => User,
         belongsTo: true,
-        foreignKeyName: "user_id"
       }
     }
   };


### PR DESCRIPTION
This small fix makes the session creation process independent of the serializer, by setting the property name.
This is maybe a dirty solution, but it is the fastest and easiest way to avoid issues due to serializer customizations. **Tested in jsonapits and chat-api.**