### PR TITLE
Adds built-in roles and permissions

### DIFF
--- a/src/application-instance.ts
+++ b/src/application-instance.ts
@@ -44,6 +44,11 @@ export default class ApplicationInstance {
       throw jsonApiErrors.InvalidToken();
     }
 
-    return <Resource>user.data;
+    const data = <Resource>user.data;
+
+    data.attributes["roles"] = await this.app.services.roles(user.data as User);
+    data.attributes["permissions"] = await this.app.services.permissions(user.data as User);
+
+    return data;
   }
 }

--- a/src/decorators/authorize.ts
+++ b/src/decorators/authorize.ts
@@ -35,6 +35,10 @@ function authorizeMiddleware(operation: Function, conditions: AttributeValueMatc
             }
           }
 
+          if (operator === "not") {
+            return !match(actual)(expected);
+          }
+
           return match(actual)(expected);
         }
 

--- a/src/decorators/if-user.ts
+++ b/src/decorators/if-user.ts
@@ -4,7 +4,7 @@ export function ifUser(attribute: string, value: string | number | boolean | str
   return { attribute, value };
 }
 
-export function ifUserNotMatches(
+export function ifUserDoesNotMatches(
   attribute: string,
   value: string | number | boolean | string[] | number[]
 ): AttributeValueMatch {
@@ -16,4 +16,28 @@ export function ifUserMatchesEvery(
   value: string | number | boolean | string[] | number[]
 ): AttributeValueMatch {
   return { attribute, value, operator: "every" };
+}
+
+export function ifUserHasRole(value: string | string[]): AttributeValueMatch {
+  return ifUser("roles", value);
+}
+
+export function ifUserHasEveryRole(value: string[]): AttributeValueMatch {
+  return ifUserMatchesEvery("roles", value);
+}
+
+export function ifUserDoesNotHaveRole(value: string | string[]): AttributeValueMatch {
+  return ifUserDoesNotMatches("roles", value);
+}
+
+export function ifUserHasPermission(value: string | string[]): AttributeValueMatch {
+  return ifUser("permissions", value);
+}
+
+export function ifUserHasEveryPermission(value: string[]): AttributeValueMatch {
+  return ifUserMatchesEvery("permissions", value);
+}
+
+export function ifUserDoesNotHavePermission(value: string | string[]): AttributeValueMatch {
+  return ifUserDoesNotMatches("permissions", value);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,14 @@ import Authorize from "./decorators/authorize";
 import decorateWith from "./decorators/decorator";
 import {
   ifUser as IfUser,
-  ifUserNotMatches as IfUserNotMatches,
-  ifUserMatchesEvery as IfUserMatchesEvery
+  ifUserDoesNotMatches as IfUserDoesNotMatches,
+  ifUserMatchesEvery as IfUserMatchesEvery,
+  ifUserDoesNotHavePermission as IfUserDoesNotHavePermission,
+  ifUserDoesNotHaveRole as IfUserDoesNotHaveRole,
+  ifUserHasEveryPermission as IfUserHasEveryPermission,
+  ifUserHasEveryRole as IfUserHasEveryRole,
+  ifUserHasPermission as IfUserHasPermission,
+  ifUserHasRole as IfUserHasRole
 } from "./decorators/if-user";
 import JsonApiErrors from "./errors/json-api-errors";
 import jsonApiKoa from "./middlewares/json-api-koa";
@@ -38,13 +44,19 @@ export {
   Authorize,
   IfUser,
   IfUserMatchesEvery,
-  IfUserNotMatches,
+  IfUserDoesNotMatches,
   // Auth module
   UserProcessor,
   SessionProcessor,
   User,
   Session,
   Password,
+  IfUserDoesNotHavePermission,
+  IfUserDoesNotHaveRole,
+  IfUserHasEveryPermission,
+  IfUserHasEveryRole,
+  IfUserHasPermission,
+  IfUserHasRole,
   // Addons
   Addon,
   UserManagementAddon,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import * as Knex from "knex";
 import Resource from "./resource";
 import Password from "./attribute-types/password";
 import Addon from "./addon";
+import User from "./resources/user";
 
 export enum HttpStatusCode {
   OK = 200,
@@ -163,6 +164,8 @@ export type EagerLoadedData = { [key: string]: KnexRecord[] | undefined };
 
 export type ApplicationServices = {
   knex?: Knex;
+  roles?: (user: User) => Promise<string[]>;
+  permissions?: (user: User) => Promise<string[]>;
 } & { [key: string]: any };
 
 export interface IJsonApiSerializer {

--- a/tests/dummy/src/app.ts
+++ b/tests/dummy/src/app.ts
@@ -24,7 +24,8 @@ const app = new Application({
 app.use(UserManagementAddon, {
   userResource: User,
   userProcessor: MyVeryOwnUserProcessor,
-  userLoginCallback: login
+  userLoginCallback: login,
+  userRolesProvider: async () => ["Admin"]
   // userGenerateIdCallback: async () => (-Date.now()).toString(),
   // userEncryptPasswordCallback: encryptPassword
 } as UserManagementAddonOptions);

--- a/tests/dummy/src/processors/user.ts
+++ b/tests/dummy/src/processors/user.ts
@@ -1,4 +1,4 @@
-import { UserProcessor, Operation, Authorize, IfUserNotMatches } from "../jsonapi-ts";
+import { UserProcessor, Operation, Authorize, IfUserDoesNotHaveRole } from "../jsonapi-ts";
 import User from "../resources/user";
 import encryptPassword from "../callbacks/encrypt-password";
 
@@ -18,14 +18,10 @@ export default class MyVeryOwnUserProcessor<T extends User> extends UserProcesso
 
     coolFactor(): number {
       return 3;
-    },
-
-    async roles() {
-      return ["user", "author", "voter"];
     }
   };
 
-  @Authorize(IfUserNotMatches("roles", ["foo"]))
+  @Authorize(IfUserDoesNotHaveRole("foo"))
   public async get(op: Operation) {
     return super.get(op);
   }


### PR DESCRIPTION
Resolves #166.

Usage:

1. Define providers for roles and permissions.

```ts
app.use(UserManagementAddon, {
  // ...
  userRolesProvider: async (user) => {
    // Do some magic to get the role names.
    return [...];
  },
  userPermissionsProvider: async (user) => {
    // Do some magic to get the permission names.
    return [...];
  }
  // ...
} as UserManagementAddonOptions);
```

2. Check for the presence of a given role/permission with the  `@Authorize` decorator:

```ts
@Authorize(IfUserHasRole("Admin"))
public async add(op: Operation) {
   // Admin-only operation. Other roles will receive a 403.
}
```