### PR TITLE
Adds UserProcessor scope for role/permission providers

### DIFF
--- a/src/application-instance.ts
+++ b/src/application-instance.ts
@@ -45,9 +45,10 @@ export default class ApplicationInstance {
     }
 
     const data = <Resource>user.data;
+    const userProcessor = await this.processorFor("user");
 
-    data.attributes["roles"] = await this.app.services.roles(user.data as User);
-    data.attributes["permissions"] = await this.app.services.permissions(user.data as User);
+    data.attributes["roles"] = await this.app.services.roles.bind(userProcessor)(user.data as User);
+    data.attributes["permissions"] = await this.app.services.permissions.bind(userProcessor)(user.data as User);
 
     return data;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import Resource from "./resource";
 import Password from "./attribute-types/password";
 import Addon from "./addon";
 import User from "./resources/user";
+import UserProcessor from "./processors/user-processor";
 
 export enum HttpStatusCode {
   OK = 200,
@@ -164,8 +165,8 @@ export type EagerLoadedData = { [key: string]: KnexRecord[] | undefined };
 
 export type ApplicationServices = {
   knex?: Knex;
-  roles?: (user: User) => Promise<string[]>;
-  permissions?: (user: User) => Promise<string[]>;
+  roles?: (this: UserProcessor<User>, user: User) => Promise<string[]>;
+  permissions?: (this: UserProcessor<User>, user: User) => Promise<string[]>;
 } & { [key: string]: any };
 
 export interface IJsonApiSerializer {

--- a/tests/dummy/src/app.ts
+++ b/tests/dummy/src/app.ts
@@ -25,7 +25,9 @@ app.use(UserManagementAddon, {
   userResource: User,
   userProcessor: MyVeryOwnUserProcessor,
   userLoginCallback: login,
-  userRolesProvider: async () => ["Admin"]
+  async userRolesProvider(this: MyVeryOwnUserProcessor<User>, user: User) {
+    return ["Admin"];
+  }
   // userGenerateIdCallback: async () => (-Date.now()).toString(),
   // userEncryptPasswordCallback: encryptPassword
 } as UserManagementAddonOptions);


### PR DESCRIPTION
Fixes a bug where provider callbacks for roles and permissions didn't have access to Knex.