### PR TITLE
Fixes pagination query to support page.number and page.size

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,9 @@ GET /books?filter[id]=ef70e4a4-5016-467b-958d-449ead0ce08e
 
 # Get the first 5 book names, sorted by name.
 GET /books?fields=name&page[number]=0&page[size]=5&sort=name
+
+# Skip 2 books, then get the next 5 books.
+GET /books?page[offset]=2&page[limit]=5
 ```
 
 The middleware, if successful, will respond with a `200 OK` HTTP status code.

--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -235,7 +235,7 @@ export default class KnexProcessor<ResourceT extends Resource> extends Operation
     }
 
     if (page) {
-      queryBuilder.offset(page.offset).limit(page.limit);
+      queryBuilder.offset(page.offset || page.number * page.size).limit(page.limit || page.size);
     }
   }
 


### PR DESCRIPTION
We were limited to the alternative syntax, `page.offset` and `page.limit`.

Fixes #188.