### PR TITLE
Fixes documentation and tests for using `fields[]` in GET queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ GET /books/ef70e4a4-5016-467b-958d-449ead0ce08e
 GET /books?filter[id]=ef70e4a4-5016-467b-958d-449ead0ce08e
 
 # Get the first 5 book names, sorted by name.
-GET /books?fields=name&page[number]=0&page[size]=5&sort=name
+GET /books?fields[book]=name&page[number]=0&page[size]=5&sort=name
 
 # Skip 2 books, then get the next 5 books.
 GET /books?page[offset]=2&page[limit]=5

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist/ && tsc -b",
     "build:dummy": "rm -rf dist/ && tsc -p tsconfig.dummy.json",
     "run:dummy": "SESSION_KEY=f0d87076b63d5c2732e282064fe6bebc tsnd tests/dummy-app/",
-    "test": "SESSION_KEY=test jest",
+    "test": "SESSION_KEY=test jest --bail",
     "prepublishOnly": "rm -rf dist/ && tsc -b"
   },
   "repository": {

--- a/tests/test-suite/acceptance/comment.test.ts
+++ b/tests/test-suite/acceptance/comment.test.ts
@@ -8,7 +8,7 @@ const request = agent(http) as SuperTest<Test>;
 describe("Comments", () => {
   describe("GET", () => {
     it("Get Comment by id - Only show the body attribute", async () => {
-      const result = await request.get("/comments/1?fields=body");
+      const result = await request.get("/comments/1?fields[comment]=body");
       expect(result.status).toEqual(200);
       expect(result.body).toEqual(comments.singleArticleNoTypeField);
     });
@@ -17,7 +17,6 @@ describe("Comments", () => {
       const result = await request.get("/comments?sort=-body");
       expect(result.status).toEqual(200);
       expect(result.body).toEqual(comments.toGetReverseSorted);
-
     });
 
     it("Get Comments - Test pagination and sorting - Should only show one ", async () => {


### PR DESCRIPTION
Resolves #187.