### PR TITLE
Post & patch tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist/ && tsc -b",
     "build:dummy": "rm -rf dist/ && tsc -p tsconfig.dummy.json",
     "run:dummy": "SESSION_KEY=f0d87076b63d5c2732e282064fe6bebc tsnd tests/dummy-app/",
-    "test": "SESSION_KEY=test jest --bail",
+    "test": "SESSION_KEY=test jest --forceExit",
     "prepublishOnly": "rm -rf dist/ && tsc -b"
   },
   "repository": {

--- a/tests/data/migrations/20190527003617_add_comments_table.ts
+++ b/tests/data/migrations/20190527003617_add_comments_table.ts
@@ -7,6 +7,7 @@ export async function up(knex: Knex): Promise<any> {
     table.string("type");
     table
       .integer("author_id")
+      .notNullable()
       .references("id")
       .inTable("users");
 

--- a/tests/dummy-app/resources/comment.ts
+++ b/tests/dummy-app/resources/comment.ts
@@ -11,8 +11,7 @@ export default class Comment extends Resource {
     relationships: {
       author: {
         type: () => User,
-        belongsTo: true,
-        foreignKeyName: "author_id"
+        belongsTo: true
       },
       parentComment: {
         type: () => Comment,

--- a/tests/test-suite/acceptance/comment.test.ts
+++ b/tests/test-suite/acceptance/comment.test.ts
@@ -25,4 +25,60 @@ describe("Comments", () => {
       expect(result.body).toEqual({ data: [comments.toGetReverseSorted.data[2]] });
     });
   });
+
+  describe("POST", () => {
+    it("Create comment - raw request", async () => {
+      const result = await request.post("/comments").send(comments.forCreation.requests.rawRequest);
+      expect(result.status).toEqual(201);
+      expect(result.body).toEqual(comments.forCreation.responses.complete);
+    });
+
+    it("Create comment - Jsonapi request", async () => {
+      const result = await request.post("/comments").send(comments.forCreation.requests.jsonapi);
+      expect(result.status).toEqual(201);
+      expect(result.body).toEqual(comments.forCreation.responses.complete);
+    });
+
+    it("Create comment - missing attribute - should have a null attribute", async () => {
+      const payload = JSON.parse(JSON.stringify(comments.forCreation.requests.jsonapi));
+      delete payload.data.attributes.body;
+      const result = await request.post("/comments").send(payload);
+      expect(result.status).toEqual(201);
+      expect(result.body).toEqual(comments.forCreation.responses.responseNoBody);
+    });
+
+    it("Create comment - missing relationship - should have a null data property in the missing relationship", async () => {
+      const payload = JSON.parse(JSON.stringify(comments.forCreation.requests.jsonapi));
+      delete payload.data.relationships.parentComment;
+      const result = await request.post("/comments").send(payload);
+      expect(result.status).toEqual(201);
+      expect(result.body).toEqual(comments.forCreation.responses.responseNoParentComment);
+    });
+
+    it("Create comment - invalid field - should fail", async () => {
+      const payload = JSON.parse(JSON.stringify(comments.forCreation.requests.jsonapi));
+      payload.data.attributes.wrongProp = "badProp";
+      const result = await request.post("/comments").send(payload);
+      expect(result.status).toEqual(500);
+    });
+  });
+
+  describe("PATCH", () => {
+    it("Update a comment - change body and parentComment", async () => {
+      const result = await request.patch(`/comments/2`).send(comments.toUpdate.attributeAndRelationship.request);
+      expect(result.body).toEqual(comments.toUpdate.attributeAndRelationship.response);
+      expect(result.status).toEqual(200);
+    });
+
+    it("Update a comment - remove a non-required relationship", async () => {
+      const result = await request.patch(`/comments/2`).send(comments.toUpdate.removeRelationship.request);
+      expect(result.body).toEqual(comments.toUpdate.removeRelationship.response);
+      expect(result.status).toEqual(200);
+    });
+
+    it("Update a comment - remove a required relationship - should fail", async () => {
+      const result = await request.patch(`/comments/2`).send(comments.toUpdate.removeRelationship.requestForError);
+      expect(result.status).toEqual(500);
+    });
+  });
 });

--- a/tests/test-suite/acceptance/factories/comment.ts
+++ b/tests/test-suite/acceptance/factories/comment.ts
@@ -1,4 +1,232 @@
 export default {
+  forCreation: {
+    requests: {
+      jsonapi: {
+        data: {
+          type: "comment",
+          attributes: {
+            body: "new commentttt",
+            type: "spam"
+          },
+          relationships: {
+            parentComment: {
+              data: {
+                id: 1,
+                type: "comment"
+              }
+            },
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            }
+          }
+        }
+      },
+      rawRequest: {
+        data: {
+          attributes: {
+            body: "new commentttt",
+            type: "spam",
+            parent_comment_id: 1,
+            author_id: 2
+          }
+        }
+      }
+    },
+    responses: {
+      complete: {
+        data: {
+          id: 4,
+          type: "comment",
+          attributes: {
+            body: "new commentttt",
+            type: "spam"
+          },
+          relationships: {
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            },
+            parentComment: {
+              data: {
+                id: 1,
+                type: "comment"
+              }
+            }
+          }
+        }
+      },
+      responseNoBody: {
+        data: {
+          id: 4,
+          type: "comment",
+          attributes: {
+            body: null,
+            type: "spam"
+          },
+          relationships: {
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            },
+            parentComment: {
+              data: {
+                id: 1,
+                type: "comment"
+              }
+            }
+          }
+        }
+      },
+      responseNoParentComment: {
+        data: {
+          id: 4,
+          type: "comment",
+          attributes: {
+            body: "new commentttt",
+            type: "spam"
+          },
+          relationships: {
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            },
+            parentComment: {
+              data: null
+            }
+          }
+        }
+      }
+    }
+  },
+  toUpdate: {
+    attributeAndRelationship: {
+      request: {
+        data: {
+          type: "comment",
+          attributes: {
+            body: "updated body",
+            type: "spam"
+          },
+          relationships: {
+            parentComment: {
+              data: {
+                id: 2,
+                type: "comment"
+              }
+            },
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            }
+          }
+        }
+      },
+      response: {
+        data: {
+          id: 2,
+          type: "comment",
+          attributes: {
+            body: "updated body",
+            type: "spam"
+          },
+          relationships: {
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            },
+            parentComment: {
+              data: {
+                id: 2,
+                type: "comment"
+              }
+            }
+          }
+        }
+      }
+    },
+    removeRelationship: {
+      request: {
+        data: {
+          type: "comment",
+          attributes: {
+            body: "updated body",
+            type: "spam"
+          },
+          relationships: {
+            parentComment: {
+              data: {
+                id: null,
+                type: "comment"
+              }
+            },
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            }
+          }
+        }
+      },
+      requestForError: {
+        data: {
+          type: "comment",
+          attributes: {
+            body: "updated body",
+            type: "spam"
+          },
+          relationships: {
+            parentComment: {
+              data: {
+                id: 1,
+                type: "comment"
+              }
+            },
+            author: {
+              data: {
+                id: null,
+                type: "user"
+              }
+            }
+          }
+        }
+      },
+      response: {
+        data: {
+          id: 2,
+          type: "comment",
+          attributes: {
+            body: "updated body",
+            type: "spam"
+          },
+          relationships: {
+            author: {
+              data: {
+                id: 2,
+                type: "user"
+              }
+            },
+            parentComment: {
+              data: null
+            }
+          }
+        }
+      }
+    }
+  },
   toGetReverseSorted: {
     data: [
       {

--- a/tests/test-suite/test-app/resources/comment.ts
+++ b/tests/test-suite/test-app/resources/comment.ts
@@ -12,7 +12,6 @@ export default class Comment extends Resource {
       author: {
         type: () => User,
         belongsTo: true,
-        foreignKeyName: "author_id"
       },
       parentComment: {
         type: () => Comment,


### PR DESCRIPTION
This adds more tests for several create and update operations.
It goes beyond the basics done in the user model, and tests differents payloads.
Everything is done in the comment model, where it has the most chance of failing, as it has several use cases (like a customized primaryKeyName, and customized and non-customized foreignKeyNames).