### PR TITLE
Test Suite optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist/ && tsc -b",
     "build:dummy": "rm -rf dist/ && tsc -p tsconfig.dummy.json",
     "run:dummy": "SESSION_KEY=f0d87076b63d5c2732e282064fe6bebc tsnd tests/dummy-app/",
+    "run:tests": "SESSION_KEY=test tsnd tests/test-suite/test-app/",
     "test": "SESSION_KEY=test jest --forceExit",
     "prepublishOnly": "rm -rf dist/ && tsc -b"
   },
@@ -80,6 +81,7 @@
           "ts",
           "js"
         ],
+        "globalSetup": "<rootDir>/tests/test-suite/globalSetup.ts",
         "setupFilesAfterEnv": [
           "<rootDir>/tests/test-suite/setup.ts"
         ],

--- a/tests/data/knexfile.ts
+++ b/tests/data/knexfile.ts
@@ -13,7 +13,7 @@ export default {
   test: {
     client: "sqlite3",
     connection: {
-      filename: ":memory:"
+      filename: join(__dirname, "test.sqlite3")
     },
     extension: "ts",
     useNullAsDefault: true,

--- a/tests/data/seeds/seed.ts
+++ b/tests/data/seeds/seed.ts
@@ -1,37 +1,37 @@
-exports.seed = (knex, Promise) => {
-  return knex("articles")
-    .del()
-    .then(() => {
-      return knex("users")
-        .insert([
-          { id: 1, username: "me", email: "me@me.com", password: "test" },
-          { id: 2, username: "username2", email: "me2@me.com", password: "test" },
-          { id: 3, username: "username3", email: "me3@me.com", password: "test" }
-        ])
-        .then(() => {
-          return knex("articles")
-            .insert([
-              { id: 1, body: "this is test 1", author: 1 },
-              { id: 2, body: "this is test 2", author: 2 },
-              { id: 3, body: "this is test 3", author: 2 }
-            ])
-            .then(() => {
-              return knex("votes")
-                .insert([
-                  { _Id: 1, points: 10, user_id: 1, article_id: 1 },
-                  { _Id: 2, points: 2, user_id: 1, article_id: 1 },
-                  { _Id: 3, points: 8, user_id: 3, article_id: 3 }
-                ])
-                .then(() => {
-                  return knex("comments")
-                    .insert([
-                      { _id: 1, body: "hello", type: "not_spam", author_id: 1, parent_comment_id: 2 },
-                      { _id: 2, body: "hello2", type: "not_spam", author_id: 2, parent_comment_id: 3 },
-                      { _id: 3, body: "hello3", type: "spam", author_id: 1 }
-                    ])
-                    .then(() => { });
-                });
-            });
-        });
-    });
+exports.seed = (knex) => {
+  const initialData = [
+    {
+      tableName: 'users',
+      values: [
+        { id: 1, username: "me", email: "me@me.com", password: "test" },
+        { id: 2, username: "username2", email: "me2@me.com", password: "test" },
+        { id: 3, username: "username3", email: "me3@me.com", password: "test" }
+      ]
+    },
+    {
+      tableName: 'articles',
+      values: [
+        { id: 1, body: "this is test 1", author: 1 },
+        { id: 2, body: "this is test 2", author: 2 },
+        { id: 3, body: "this is test 3", author: 2 }
+      ]
+    },
+    {
+      tableName: 'votes',
+      values: [
+        { _Id: 1, points: 10, user_id: 1, article_id: 1 },
+        { _Id: 2, points: 2, user_id: 1, article_id: 1 },
+        { _Id: 3, points: 8, user_id: 3, article_id: 3 }
+      ]
+    },
+    {
+      tableName: 'comments',
+      values: [
+        { _id: 1, body: "hello", type: "not_spam", author_id: 1, parent_comment_id: 2 },
+        { _id: 2, body: "hello2", type: "not_spam", author_id: 2, parent_comment_id: 3 },
+        { _id: 3, body: "hello3", type: "spam", author_id: 1 }
+      ]
+    }
+  ];
+  return Promise.all(initialData.map(({ tableName, values }) => knex(tableName).insert(values))).then(() => { });
 };

--- a/tests/test-suite/acceptance/user.test.ts
+++ b/tests/test-suite/acceptance/user.test.ts
@@ -7,22 +7,6 @@ import getAuthenticationData from "./helpers/authenticateUser";
 const request = agent(http) as SuperTest<Test>;
 
 describe("Users", () => {
-  describe("POST", () => {
-    it("Create user", async () => {
-      const result = await request.post("/users").send(users.forCreation.request);
-      expect(result.status).toEqual(201);
-      expect(result.body).toEqual(users.forCreation.response);
-    });
-  });
-
-  describe("PATCH", () => {
-    it("Update a user", async () => {
-      const result = await request.patch(`/users/2`).send(users.toUpdate.dataToUpdate);
-      expect(result.body).toEqual(users.toUpdate.response);
-      expect(result.status).toEqual(200);
-    });
-  });
-
   describe("GET", () => {
     it("Authenticated - Get all users", async () => {
       const authData = await getAuthenticationData();
@@ -43,6 +27,22 @@ describe("Users", () => {
       const result = await request.get("/users?filter[email]=me@me.com").set("Authorization", authData.token);
       expect(result.status).toEqual(200);
       expect(result.body).toEqual({ data: [users.toGet[0]] });
+    });
+  });
+
+  describe("POST", () => {
+    it("Create user", async () => {
+      const result = await request.post("/users").send(users.forCreation.request);
+      expect(result.status).toEqual(201);
+      expect(result.body).toEqual(users.forCreation.response);
+    });
+  });
+
+  describe("PATCH", () => {
+    it("Update a user", async () => {
+      const result = await request.patch(`/users/2`).send(users.toUpdate.dataToUpdate);
+      expect(result.body).toEqual(users.toUpdate.response);
+      expect(result.status).toEqual(200);
     });
   });
 

--- a/tests/test-suite/globalSetup.ts
+++ b/tests/test-suite/globalSetup.ts
@@ -1,0 +1,7 @@
+import app from "./test-app/app";
+
+module.exports = async () => {
+  await app.services.knex.migrate.rollback()
+  await app.services.knex.migrate.latest();
+  await app.services.knex.seed.run();
+}

--- a/tests/test-suite/setup.ts
+++ b/tests/test-suite/setup.ts
@@ -4,8 +4,6 @@ import context from "./transaction";
 
 const knex = app.services.knex;
 
-let migrationTransaction: Transaction;
-
 const createTransaction = (connection, callback): Promise<Transaction> => {
   return new Promise(resolve =>
     connection
@@ -17,19 +15,9 @@ const createTransaction = (connection, callback): Promise<Transaction> => {
   );
 };
 
-beforeAll(async () => {
-  migrationTransaction = await createTransaction(knex, () => { });
-  await migrationTransaction.migrate.latest();
-  await migrationTransaction.seed.run();
-});
-
-afterAll(async () => {
-  await migrationTransaction.rollback();
-});
-
 beforeEach(async () => {
-  context.transaction = await createTransaction(migrationTransaction, t => {
-    app.services.knex = t;
+  context.transaction = await createTransaction(knex, transaction => {
+    app.services.knex = transaction;
   });
 });
 


### PR DESCRIPTION
This PR simplifies the test process, by migrating and seeding **just once the DB**, and then working with transactions on each test.
It also does some cleaning up of the seed file.
And it leaves ready to use the parallel test-app to test things, together with the test DB, when tests don't pass and we don't know why.

I wasn't able to optimize really much the running time, I'm not aware why it takes so long on the first run (15 seconds), luckilly, the following runs are down to 4.2s.