### PR TITLE
Add serialization testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.log
 package-lock.json
 test.sqlite3
+test.sqlite3-journal

--- a/package.json
+++ b/package.json
@@ -56,13 +56,14 @@
     "typescript": "^3.4"
   },
   "jest": {
+    "globalSetup": "<rootDir>/tests/test-suite/globalSetup.ts",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
     "projects": [
       {
         "displayName": "unit",
-        "moduleFileExtensions": [
-          "ts",
-          "js"
-        ],
         "transform": {
           "^.+\\.(ts)$": "ts-jest"
         },
@@ -76,12 +77,7 @@
         ]
       },
       {
-        "displayName": "acceptance",
-        "moduleFileExtensions": [
-          "ts",
-          "js"
-        ],
-        "globalSetup": "<rootDir>/tests/test-suite/globalSetup.ts",
+        "displayName": "acceptance - snake_case",
         "setupFilesAfterEnv": [
           "<rootDir>/tests/test-suite/setup.ts"
         ],
@@ -89,6 +85,25 @@
           "^.+\\.(ts)$": "ts-jest"
         },
         "globals": {
+          "TEST_SUITE": "test_snake_case",
+          "ts-jest": {
+            "tsConfig": "tsconfig.test.json"
+          }
+        },
+        "testMatch": [
+          "<rootDir>/tests/test-suite/acceptance/**/?(*.)+(spec|test).ts"
+        ]
+      },
+      {
+        "displayName": "acceptance - camelCase",
+        "setupFilesAfterEnv": [
+          "<rootDir>/tests/test-suite/setup.ts"
+        ],
+        "transform": {
+          "^.+\\.(ts)$": "ts-jest"
+        },
+        "globals": {
+          "TEST_SUITE": "test_camelCase",
           "ts-jest": {
             "tsConfig": "tsconfig.test.json"
           }

--- a/tests/data/camelCase/migrations/20190506190057_add_users_table.ts
+++ b/tests/data/camelCase/migrations/20190506190057_add_users_table.ts
@@ -1,0 +1,16 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.createTable("users", table => {
+    table.increments("id").primary();
+    table.string("username");
+    table.string("email");
+    table.string("password");
+    table.dateTime("createdAt");
+    table.dateTime("updatedAt");
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable("users");
+}

--- a/tests/data/camelCase/migrations/20190506190058_add_articles_table.ts
+++ b/tests/data/camelCase/migrations/20190506190058_add_articles_table.ts
@@ -1,0 +1,18 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.createTable("articles", table => {
+    table.increments("id").primary();
+    table.string("body");
+    table
+      .integer("author")
+      .references("id")
+      .inTable("users");
+    table.dateTime("createdAt");
+    table.dateTime("updatedAt");
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable("articles");
+}

--- a/tests/data/camelCase/migrations/20190523003617_add_votes_table.ts
+++ b/tests/data/camelCase/migrations/20190523003617_add_votes_table.ts
@@ -1,4 +1,4 @@
-import Knex from "knex";
+import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.createTable("votes", table => {
@@ -11,12 +11,12 @@ export async function up(knex: Knex): Promise<any> {
     table.integer("createdBy");
 
     table
-      .integer("user_id")
+      .integer("userId")
       .references("id")
       .inTable("users");
 
     table
-      .integer("article_id")
+      .integer("articleId")
       .references("id")
       .inTable("articles");
   });

--- a/tests/data/camelCase/migrations/20190527003617_add_comments_table.ts
+++ b/tests/data/camelCase/migrations/20190527003617_add_comments_table.ts
@@ -1,4 +1,4 @@
-import Knex from "knex";
+import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.createTable("comments", table => {
@@ -12,7 +12,7 @@ export async function up(knex: Knex): Promise<any> {
       .inTable("users");
 
     table
-      .integer("parent_comment_id")
+      .integer("parentCommentId")
       .references("_id")
       .inTable("comments");
   });

--- a/tests/data/camelCase/seeds/seed.ts
+++ b/tests/data/camelCase/seeds/seed.ts
@@ -19,16 +19,16 @@ exports.seed = (knex) => {
     {
       tableName: 'votes',
       values: [
-        { _Id: 1, points: 10, user_id: 1, article_id: 1 },
-        { _Id: 2, points: 2, user_id: 1, article_id: 1 },
-        { _Id: 3, points: 8, user_id: 3, article_id: 3 }
+        { _Id: 1, points: 10, userId: 1, articleId: 1 },
+        { _Id: 2, points: 2, userId: 1, articleId: 1 },
+        { _Id: 3, points: 8, userId: 3, articleId: 3 }
       ]
     },
     {
       tableName: 'comments',
       values: [
-        { _id: 1, body: "hello", type: "not_spam", author_id: 1, parent_comment_id: 2 },
-        { _id: 2, body: "hello2", type: "not_spam", author_id: 2, parent_comment_id: 3 },
+        { _id: 1, body: "hello", type: "not_spam", author_id: 1, parentCommentId: 2 },
+        { _id: 2, body: "hello2", type: "not_spam", author_id: 2, parentCommentId: 3 },
         { _id: 3, body: "hello3", type: "spam", author_id: 1 }
       ]
     }

--- a/tests/data/knexfile.ts
+++ b/tests/data/knexfile.ts
@@ -10,18 +10,32 @@ export default {
     useNullAsDefault: true,
     debug: true
   },
-  test: {
+  test_snake_case: {
     client: "sqlite3",
     connection: {
-      filename: join(__dirname, "test.sqlite3")
+      filename: join(__dirname, "snake_case", "test.sqlite3")
     },
     extension: "ts",
     useNullAsDefault: true,
     seeds: {
-      directory: join(__dirname, "seeds")
+      directory: join(__dirname, "snake_case", "seeds")
     },
     migrations: {
-      directory: join(__dirname, "migrations")
+      directory: join(__dirname, "snake_case", "migrations")
+    }
+  },
+  test_camelCase: {
+    client: "sqlite3",
+    connection: {
+      filename: join(__dirname, "camelCase", "test.sqlite3")
+    },
+    extension: "ts",
+    useNullAsDefault: true,
+    seeds: {
+      directory: join(__dirname, "camelCase", "seeds")
+    },
+    migrations: {
+      directory: join(__dirname, "camelCase", "migrations")
     }
   }
 };

--- a/tests/data/snake_case/migrations/20190506190057_add_users_table.ts
+++ b/tests/data/snake_case/migrations/20190506190057_add_users_table.ts
@@ -1,4 +1,4 @@
-import Knex from "knex";
+import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.createTable("users", table => {
@@ -6,7 +6,8 @@ export async function up(knex: Knex): Promise<any> {
     table.string("username");
     table.string("email");
     table.string("password");
-    table.timestamps();
+    table.dateTime("created_at");
+    table.dateTime("updated_at");
   });
 }
 

--- a/tests/data/snake_case/migrations/20190506190058_add_articles_table.ts
+++ b/tests/data/snake_case/migrations/20190506190058_add_articles_table.ts
@@ -1,4 +1,4 @@
-import Knex from "knex";
+import * as Knex from "knex";
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.createTable("articles", table => {
@@ -8,7 +8,9 @@ export async function up(knex: Knex): Promise<any> {
       .integer("author")
       .references("id")
       .inTable("users");
-    table.timestamps();
+    table.dateTime("created_at");
+    table.dateTime("updated_at");
+
   });
 }
 

--- a/tests/data/snake_case/migrations/20190523003617_add_votes_table.ts
+++ b/tests/data/snake_case/migrations/20190523003617_add_votes_table.ts
@@ -1,0 +1,27 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.createTable("votes", table => {
+    table.increments("_Id").primary();
+    table.integer("points");
+
+    table.dateTime("created_on");
+    table.dateTime("updated_on");
+    table.integer("updated_by");
+    table.integer("created_by");
+
+    table
+      .integer("user_id")
+      .references("id")
+      .inTable("users");
+
+    table
+      .integer("article_id")
+      .references("id")
+      .inTable("articles");
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable("votes");
+}

--- a/tests/data/snake_case/migrations/20190527003617_add_comments_table.ts
+++ b/tests/data/snake_case/migrations/20190527003617_add_comments_table.ts
@@ -1,0 +1,23 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.createTable("comments", table => {
+    table.increments("_id").primary();
+    table.string("body");
+    table.string("type");
+    table
+      .integer("author_id")
+      .notNullable()
+      .references("id")
+      .inTable("users");
+
+    table
+      .integer("parent_comment_id")
+      .references("_id")
+      .inTable("comments");
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable("comments");
+}

--- a/tests/data/snake_case/seeds/seed.ts
+++ b/tests/data/snake_case/seeds/seed.ts
@@ -1,0 +1,38 @@
+import * as Knex from "knex";
+exports.seed = (knex: Knex) => {
+  const initialData = [
+    {
+      tableName: 'users',
+      values: [
+        { id: 1, username: "me", email: "me@me.com", password: "test" },
+        { id: 2, username: "username2", email: "me2@me.com", password: "test" },
+        { id: 3, username: "username3", email: "me3@me.com", password: "test" }
+      ]
+    },
+    {
+      tableName: 'articles',
+      values: [
+        { id: 1, body: "this is test 1", author: 1 },
+        { id: 2, body: "this is test 2", author: 2 },
+        { id: 3, body: "this is test 3", author: 2 }
+      ]
+    },
+    {
+      tableName: 'votes',
+      values: [
+        { _Id: 1, points: 10, user_id: 1, article_id: 1 },
+        { _Id: 2, points: 2, user_id: 1, article_id: 1 },
+        { _Id: 3, points: 8, user_id: 3, article_id: 3 }
+      ]
+    },
+    {
+      tableName: 'comments',
+      values: [
+        { _id: 1, body: "hello", type: "not_spam", author_id: 1, parent_comment_id: 2 },
+        { _id: 2, body: "hello2", type: "not_spam", author_id: 2, parent_comment_id: 3 },
+        { _id: 3, body: "hello3", type: "spam", author_id: 1 }
+      ]
+    }
+  ];
+  return Promise.all(initialData.map(({ tableName, values }) => knex(tableName).insert(values))).then(() => { });
+};

--- a/tests/test-suite/acceptance/comment.test.ts
+++ b/tests/test-suite/acceptance/comment.test.ts
@@ -10,7 +10,7 @@ describe("Comments", () => {
     it("Get Comment - Test field filter - Should show only the body attribute", async () => {
       const result = await request.get("/comments/1?fields[comment]=body");
       expect(result.status).toEqual(200);
-      expect(result.body).toEqual(comments.singleArticleNoTypeField);
+      expect(result.body).toEqual(comments.singleCommentNoType);
     });
 
     it("List Comments - Test sorting - Should be sorted by body field", async () => {
@@ -24,11 +24,21 @@ describe("Comments", () => {
       expect(result.status).toEqual(200);
       expect(result.body).toEqual({ data: [comments.toGetReverseSorted.data[2]] });
     });
+
+    it("List Comments - Test pagination - Should only show one", async () => {
+      const result = await request.get("/comments/1?include=parentComment");
+      expect(result.status).toEqual(200);
+      expect(result.body).toEqual(comments.singleCommentWithReflexiveInclude);
+    });
   });
 
   describe("POST", () => {
     it("Create comment - raw request", async () => {
-      const result = await request.post("/comments").send(comments.forCreation.requests.rawRequest);
+      const data =
+        global["TEST_SUITE"] === "test_camelCase"
+          ? comments.forCreation.requests.rawRequestCamelCase
+          : comments.forCreation.requests.rawRequestSnakeCase;
+      const result = await request.post("/comments").send(data);
       expect(result.status).toEqual(201);
       expect(result.body).toEqual(comments.forCreation.responses.complete);
     });

--- a/tests/test-suite/acceptance/factories/comment.ts
+++ b/tests/test-suite/acceptance/factories/comment.ts
@@ -24,13 +24,23 @@ export default {
           }
         }
       },
-      rawRequest: {
+      rawRequestSnakeCase: {
         data: {
           attributes: {
             body: "new commentttt",
             type: "spam",
-            parent_comment_id: 1,
-            author_id: 2
+            author_id: 2,
+            parent_comment_id: 1
+          }
+        }
+      },
+      rawRequestCamelCase: {
+        data: {
+          attributes: {
+            body: "new commentttt",
+            type: "spam",
+            author_id: 2,
+            parentCommentId: 1
           }
         }
       }
@@ -294,7 +304,7 @@ export default {
       }
     ]
   },
-  singleArticleNoTypeField: {
+  singleCommentNoType: {
     data: {
       id: 1,
       type: "comment",
@@ -316,5 +326,27 @@ export default {
         }
       }
     }
+  },
+  singleCommentWithReflexiveInclude: {
+    data: {
+      id: 1,
+      type: "comment",
+      attributes: { body: "hello", type: "not_spam" },
+      relationships: {
+        parentComment: { data: { id: 2, type: "comment" } },
+        author: { data: { id: 1, type: "user" } }
+      }
+    },
+    included: [
+      {
+        id: 2,
+        type: "comment",
+        attributes: { body: "hello2", type: "not_spam" },
+        relationships: {
+          author: { data: { id: 2, type: "user" } },
+          parentComment: { data: { id: 3, type: "comment" } }
+        }
+      }
+    ]
   }
 };

--- a/tests/test-suite/acceptance/factories/vote.ts
+++ b/tests/test-suite/acceptance/factories/vote.ts
@@ -1,0 +1,59 @@
+export default {
+  toGetIncludedUserAndArticle: {
+    data: {
+      id: 1,
+      type: "vote",
+      attributes: {
+        points: 10,
+        createdOn: null,
+        updatedOn: null,
+        updatedBy: null,
+        createdBy: null
+      },
+      relationships: {
+        user: {
+          data: {
+            id: 1,
+            type: "user"
+          }
+        },
+        article: {
+          data: {
+            id: 1,
+            type: "article"
+          }
+        }
+      }
+    },
+    included: [
+      {
+        id: 1,
+        type: "user",
+        attributes: {
+          username: "me",
+          email: "me@me.com",
+          createdAt: null,
+          updatedAt: null
+        },
+        relationships: {}
+      },
+      {
+        id: 1,
+        type: "article",
+        attributes: {
+          body: "this is test 1",
+          createdAt: null,
+          updatedAt: null
+        },
+        relationships: {
+          author: {
+            data: {
+              id: 1,
+              type: "user"
+            }
+          }
+        }
+      }
+    ]
+  }
+};

--- a/tests/test-suite/acceptance/vote.test.ts
+++ b/tests/test-suite/acceptance/vote.test.ts
@@ -1,0 +1,18 @@
+import { SuperTest, Test } from "supertest";
+import * as agent from "supertest-koa-agent";
+import vote from "./factories/vote";
+import http from "../test-app/http";
+import getAuthenticationData from "./helpers/authenticateUser";
+
+const request = agent(http) as SuperTest<Test>;
+
+describe("Votes", () => {
+  describe("GET", () => {
+    it("Gets vote by id", async () => {
+      const { token } = await getAuthenticationData();
+      const result = await request.get(`/votes/1?include=user,article`).set("Authorization", token);
+      expect(result.status).toEqual(200);
+      expect(result.body).toEqual(vote.toGetIncludedUserAndArticle);
+    });
+  });
+});

--- a/tests/test-suite/globalSetup.ts
+++ b/tests/test-suite/globalSetup.ts
@@ -1,7 +1,15 @@
+import knexfile from "../data/knexfile";
+import * as Knex from "knex";
 import app from "./test-app/app";
 
 module.exports = async () => {
-  await app.services.knex.migrate.rollback()
+  app.services.knex = Knex(knexfile["test_snake_case"]);
+  await app.services.knex.migrate.rollback();
   await app.services.knex.migrate.latest();
   await app.services.knex.seed.run();
-}
+
+  app.services.knex = Knex(knexfile["test_camelCase"]);
+  await app.services.knex.migrate.rollback();
+  await app.services.knex.migrate.latest();
+  await app.services.knex.seed.run();
+};

--- a/tests/test-suite/setup.ts
+++ b/tests/test-suite/setup.ts
@@ -1,22 +1,28 @@
-import { Transaction } from "knex";
+import * as Knex from "knex";
 import app from "./test-app/app";
 import context from "./transaction";
-
-const knex = app.services.knex;
-
-const createTransaction = (connection, callback): Promise<Transaction> => {
+import knexfile from "../data/knexfile";
+import Serializer from "./test-app/serializers/serializer";
+let knexInstance;
+const createTransaction = (connection, callback): Promise<Knex.Transaction> => {
   return new Promise(resolve =>
     connection
       .transaction(t => {
         callback(t);
         return resolve(t);
       })
-      .catch(e => { })
+      .catch(t => { })
   );
 };
+const serializer = global["TEST_SUITE"] === "test_snake_case" ? app.serializer : new Serializer();
+
+beforeAll(async () => {
+  knexInstance = await createTransaction(Knex(knexfile[global["TEST_SUITE"]]), () => { });
+  app.serializer = serializer;
+});
 
 beforeEach(async () => {
-  context.transaction = await createTransaction(knex, transaction => {
+  context.transaction = await createTransaction(knexInstance, transaction => {
     app.services.knex = transaction;
   });
 });

--- a/tests/test-suite/test-app/app.ts
+++ b/tests/test-suite/test-app/app.ts
@@ -28,7 +28,5 @@ app.use(UserManagementAddon, {
   // userGenerateIdCallback: async () => (-Date.now()).toString(),
   // userEncryptPasswordCallback: encryptPassword
 } as UserManagementAddonOptions);
-
-app.services.knex = Knex(knexfile["test"]);
-
+app.services.knex = app.services.knex || Knex(knexfile["test_camelCase"]);
 export default app;

--- a/tests/test-suite/test-app/processors/article.ts
+++ b/tests/test-suite/test-app/processors/article.ts
@@ -11,7 +11,7 @@ export default class ArticleProcessor<ResourceT extends Article> extends KnexPro
 
       const [result] = await processor
         .getQuery()
-        .where({ article_id: article.id })
+        .where({ [this.appInstance.app.serializer.relationshipToColumn('article', 'id')]: article.id })
         .count();
 
       return result["count(*)"];

--- a/tests/test-suite/test-app/resources/article.ts
+++ b/tests/test-suite/test-app/resources/article.ts
@@ -16,8 +16,7 @@ export default class Article extends Resource {
       },
       votes: {
         type: () => Vote,
-        hasMany: true,
-        foreignKeyName: "article_id"
+        hasMany: true
       }
     }
   };

--- a/tests/test-suite/test-app/resources/comment.ts
+++ b/tests/test-suite/test-app/resources/comment.ts
@@ -12,11 +12,11 @@ export default class Comment extends Resource {
       author: {
         type: () => User,
         belongsTo: true,
+        foreignKeyName: "author_id"
       },
       parentComment: {
         type: () => Comment,
         belongsTo: true,
-        foreignKeyName: "parent_comment_id"
       }
     }
   };

--- a/tests/test-suite/test-app/resources/vote.ts
+++ b/tests/test-suite/test-app/resources/vote.ts
@@ -20,8 +20,7 @@ export default class Vote extends Resource {
       },
       article: {
         type: () => Article,
-        belongsTo: true,
-        foreignKeyName: "article_id"
+        belongsTo: true
       }
     }
   };

--- a/tests/test-suite/test-app/serializers/serializer.ts
+++ b/tests/test-suite/test-app/serializers/serializer.ts
@@ -1,0 +1,27 @@
+import { JsonApiSerializer, pluralize } from "./../jsonapi-ts";
+
+export default class Serializer extends JsonApiSerializer {
+  resourceTypeToTableName(resourceType: string): string {
+    return pluralize(resourceType);
+  }
+
+  attributeToColumn(attributeName: string): string {
+    return attributeName;
+  }
+
+  columnToAttribute(columnName: string): string {
+    return columnName;
+  }
+
+  columnToRelationship(columnName: string, primaryKeyName: string = "Id"): string {
+    return this.columnToAttribute(columnName.replace(`${'Id'}`, ""));
+  }
+
+  relationshipToColumn(relationshipName: string, primaryKeyName: string = "Id"): string {
+    return `${relationshipName}${'Id'}`;
+  }
+
+  foreignResourceToForeignTableName(foreignResourceType: string, prefix: string = "belonging"): string {
+    return `${prefix} ${this.resourceTypeToTableName(foreignResourceType)}`;
+  }
+}


### PR DESCRIPTION
This PR duplicates the number of environments to test onto, to account for the possibility of different serialization implementations (for different column names in the database level): the default and a custom one (I used the one from the chat-app as an example).
It also adds some more tests, to check this specific thing, in both environments.

Currently throwing the 2 errors that it suppossed to throw (for the unauthenticated requests, on both environments). 

