### PR TITLE
Prevents access to unauthorized resources via `included`

### DIFF
--- a/src/decorators/authorize.ts
+++ b/src/decorators/authorize.ts
@@ -3,61 +3,72 @@ import { AttributeValueMatch, AttributeValue } from "../types";
 
 import decorateWith from "./decorator";
 import OperationProcessor from "../processors/operation-processor";
-import { Resource } from "..";
+import Resource from "../resource";
+import ApplicationInstance from "../application-instance";
 
 type PrimitiveValue = string | number | boolean | object;
 
 const match = (actual: AttributeValue) => (item: PrimitiveValue) => (actual as any[]).includes(item);
+const ACCESS_RULES = Symbol("accessRules");
+
+function conditionsPass(
+  appInstance: ApplicationInstance,
+  { attribute, value, operator = "some" }: AttributeValueMatch
+) {
+  const actual: AttributeValue = appInstance.user.attributes[attribute];
+  const expected = value;
+
+  if (Array.isArray(actual)) {
+    if (Array.isArray(expected)) {
+      if (operator === "some") {
+        return expected.some(match(actual));
+      }
+
+      if (operator === "every") {
+        return expected.every(match(actual));
+      }
+
+      if (operator === "not") {
+        return !expected.every(match(actual));
+      }
+    }
+
+    if (operator === "not") {
+      return !match(actual)(expected);
+    }
+
+    return match(actual)(expected);
+  }
+
+  if (Array.isArray(expected)) {
+    return match(expected)(actual);
+  }
+
+  if (operator === "not") {
+    return actual !== expected;
+  }
+
+  return actual === expected;
+}
 
 function authorizeMiddleware(operation: Function, conditions: AttributeValueMatch[]) {
-  return function(this: OperationProcessor<Resource>) {
+  const callback = function(this: OperationProcessor<Resource>) {
+    this.constructor["accessRules"][operation.name] = conditions;
+
     if (!this.appInstance.user) {
       throw JsonApiErrors.Unauthorized();
     }
 
-    if (
-      !conditions.every(({ attribute, value, operator = "some" }: AttributeValueMatch) => {
-        const actual: AttributeValue = this.appInstance.user.attributes[attribute];
-        const expected = value;
-
-        if (Array.isArray(actual)) {
-          if (Array.isArray(expected)) {
-            if (operator === "some") {
-              return expected.some(match(actual));
-            }
-
-            if (operator === "every") {
-              return expected.every(match(actual));
-            }
-
-            if (operator === "not") {
-              return !expected.every(match(actual));
-            }
-          }
-
-          if (operator === "not") {
-            return !match(actual)(expected);
-          }
-
-          return match(actual)(expected);
-        }
-
-        if (Array.isArray(expected)) {
-          return match(expected)(actual);
-        }
-
-        if (operator === "not") {
-          return actual !== expected;
-        }
-
-        return actual === expected;
-      })
-    ) {
+    if (!conditions.every((condition: AttributeValueMatch) => conditionsPass(this.appInstance, condition))) {
       throw JsonApiErrors.AccessDenied();
     }
 
     return operation.call(this, ...arguments);
   };
+
+  callback[ACCESS_RULES] = conditions;
+
+  return callback;
 }
 
 /**
@@ -67,4 +78,15 @@ function authorizeMiddleware(operation: Function, conditions: AttributeValueMatc
  */
 export default function authorize(...conditions: AttributeValueMatch[]) {
   return decorateWith(authorizeMiddleware, conditions);
+}
+
+export async function canAccessResource(resource: Resource, operationName: string, appInstance: ApplicationInstance) {
+  const processor = await appInstance.processorFor(resource.type);
+  const accessRules = processor[operationName][ACCESS_RULES] || [];
+
+  if (!accessRules.length) {
+    return true;
+  }
+
+  return accessRules.every((condition: AttributeValueMatch) => conditionsPass(appInstance, condition));
 }

--- a/src/decorators/authorize.ts
+++ b/src/decorators/authorize.ts
@@ -53,8 +53,6 @@ function conditionsPass(
 
 function authorizeMiddleware(operation: Function, conditions: AttributeValueMatch[]) {
   const callback = function(this: OperationProcessor<Resource>) {
-    this.constructor["accessRules"][operation.name] = conditions;
-
     if (!this.appInstance.user) {
       throw JsonApiErrors.Unauthorized();
     }
@@ -86,6 +84,10 @@ export async function canAccessResource(resource: Resource, operationName: strin
 
   if (!accessRules.length) {
     return true;
+  }
+
+  if (!appInstance.user) {
+    return false;
   }
 
   return accessRules.every((condition: AttributeValueMatch) => conditionsPass(appInstance, condition));

--- a/tests/test-suite/acceptance/article.test.ts
+++ b/tests/test-suite/acceptance/article.test.ts
@@ -45,10 +45,9 @@ describe("Articles", () => {
       expect(result.body).toEqual(articles.singleArticleMultipleIncludes);
     });
 
-    // TODO: THIS SHOULD'NT WORK WELL - EITHER 401 or simply don't show the author
-    it.skip("UNAuthenticated - Get an specific article with it's author - Should fail", async () => {
+    it("UNAuthenticated - Get an specific article with it's author - Should not include author", async () => {
       const result = await request.get("/articles/1?include=author");
-      expect(result.status).toEqual(401);
+      expect(result.body.included).toEqual(undefined);
     });
   });
 });


### PR DESCRIPTION
This PR extracts the condition evaluation code of the `@Authorize` decorator into a separate function `conditionsPass` that is now shared with the original decorator and a new filtering function called `canAccessResource`.

This new function is now used by the `Application#buildOperationResponse` function to exclude from the `included` resources array any resources that aren't authorized by the conditions applied on their processors using `@Authorize`.

The trick is to decorate the function with a `Symbol` called `accessRules`, which copies the conditions passed to the decorator for further evaluation. Then, `canAccessResource` is called after `serializeIncludedResources` to remove any unauthorized resources when it returns `false`.

Resolves #186.

Also, it enables us to re-activate the test commented by #200.