### PR TITLE
add more knex processor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ Apart from the operations, this processor has some other methods, that operation
 | `getQuery` | Returns an instance of [Knex.QueryBuilder](https://knexjs.org/#Builder), scoped to the table specified by `tableName` (the processor resource's data source) |
 | `tableName`     | Returns the table name for the resource handled by the processor                     |
 
-Using these two methods and the normal [knex functions](https://knexjs.org), you can extend however you want a processor.
+Using these two methods and the standard [Knex functions](https://knexjs.org/#Builder-wheres), you can extend a processor anyway you want to.
 
 ### Extending the `KnexProcessor` class
 

--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ Apart from the operations, this processor has some other methods, that operation
 | Method    | Description                                        |
 | --------- | ---------------------------------------------------- |
 | `getQuery` | Returns an instance of [Knex.QueryBuilder](https://knexjs.org/#Builder), scoped to the table specified by `tableName` (the processor resource's data source) |
-| `tableName`     | Returns the table name of the resource of the processor                     |
+| `tableName`     | Returns the table name for the resource handled by the processor                     |
 
 Using these two methods and the normal [knex functions](https://knexjs.org), you can extend however you want a processor.
 

--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ class CommentProcessor<T extends Comment> extends KnexProcessor<T> {
 
 Any computed properties you define will be included in the resource on any operation. **Do not** declare these computed properties in the resource's schema, as JSONAPI-TS will interpret them as columns in a table and fail due to non-existing columns.
 
-### The `KnexProcessor` class
+## The `KnexProcessor` class
 
 This processor is a fully-implemented, database-driven extension of the `OperationProcessor` class seen before. It takes care of creating the necessary SQL queries to resolve any given operation.
 
@@ -912,6 +912,15 @@ It maps operations to queries like this:
 |           |                                                      |
 
 It receives a single argument, `options`, which is passed to the `Knex` constructor. See the [Knex documentation](https://knexjs.org/#Installation-client) for detailed examples.
+
+Apart from the operations, this processor has some other methods, that operations use (so tread carefully here), that you can use while making custom operations.
+
+| Method    | functionality                                        |
+| --------- | ---------------------------------------------------- |
+| `getQuery`| The common method to start a SQL request, starting with the table of the resource of the processor |
+| `tableName`     | Returns the table name of the resource of the processor                     |
+
+Using these two methods and the normal [knex functions](https://knexjs.org), you can extend however you want a processor.
 
 ### Extending the `KnexProcessor` class
 
@@ -937,6 +946,8 @@ export default class BookProcessor extends KnexProcessor<Book> {
 The call to `super.get(op)` allows to reuse the behavior of the KnexProcessor and then do other actions around it.
 
 > ℹ️ Naturally, there are better ways to do a count. This is just an example to show the extensibility capabilities of the processor.
+
+> ℹ️ A thing to remember, is that JsonApiKoa won't parse the custom operations into endpoints, so to reach the custom operation from a HTTP request, you should use the *bulk* endpoint (or a JsonApiWebsockets operation), or execute the operation inside some of the default methods of the processor (with an if inside a GET, for example).
 
 ## Serialization
 

--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ It maps operations to queries like this:
 
 It receives a single argument, `options`, which is passed to the `Knex` constructor. See the [Knex documentation](https://knexjs.org/#Installation-client) for detailed examples.
 
-Apart from the operations, this processor has some other methods, that operations use (so tread carefully here), that you can use while making custom operations.
+In addition to the operation handlers, this processor has some other methods that you can use while making custom operations. Note that all operations use these functions, so tread carefully here if you're interested in overriding them.
 
 | Method    | Description                                        |
 | --------- | ---------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ Apart from the operations, this processor has some other methods, that operation
 
 | Method    | Description                                        |
 | --------- | ---------------------------------------------------- |
-| `getQuery`| The common method to start a SQL request, starting with the table of the resource of the processor |
+| `getQuery` | Returns an instance of [Knex.QueryBuilder](https://knexjs.org/#Builder), scoped to the table specified by `tableName` (the processor resource's data source) |
 | `tableName`     | Returns the table name of the resource of the processor                     |
 
 Using these two methods and the normal [knex functions](https://knexjs.org), you can extend however you want a processor.

--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ It receives a single argument, `options`, which is passed to the `Knex` construc
 
 Apart from the operations, this processor has some other methods, that operations use (so tread carefully here), that you can use while making custom operations.
 
-| Method    | functionality                                        |
+| Method    | Description                                        |
 | --------- | ---------------------------------------------------- |
 | `getQuery`| The common method to start a SQL request, starting with the table of the resource of the processor |
 | `tableName`     | Returns the table name of the resource of the processor                     |


### PR DESCRIPTION
closes #176 
Upon discussion with @joelalejandro, we decided to not to document all the knexProcessor functions, as some don't make sense to use/extend, while extending the class behaviour.

