### PR TITLE
Express Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist/ && tsc -b",
     "build:dummy": "rm -rf dist/ && tsc -p tsconfig.dummy.json",
     "run:dummy": "SESSION_KEY=f0d87076b63d5c2732e282064fe6bebc tsnd tests/dummy-app/",
-    "run:tests": "SESSION_KEY=test tsnd tests/test-suite/test-app/",
+    "run:test-app": "SESSION_KEY=test tsnd tests/test-suite/test-app/",
     "test": "SESSION_KEY=test jest --forceExit",
     "prepublishOnly": "rm -rf dist/ && tsc -b"
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
   },
   "homepage": "https://github.com/ebryn/jsonapi-ts#readme",
   "dependencies": {
+    "@types/express": "^4.16.1",
+    "compose-middleware": "^5.0.1",
     "ember-cli-string-utils": "^1.1.0",
     "escape-string-regexp": "^1.0.5",
+    "express": "^4.17.1",
     "jsonwebtoken": "^8.4.0",
     "knex": "~0.16.5",
     "koa": "^2.6.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from "./decorators/if-user";
 import JsonApiErrors from "./errors/json-api-errors";
 import jsonApiKoa from "./middlewares/json-api-koa";
+import jsonApiExpress from "./middlewares/json-api-express";
 import jsonApiWebSocket from "./middlewares/json-api-websocket";
 import KnexProcessor from "./processors/knex-processor";
 import OperationProcessor from "./processors/operation-processor";
@@ -32,6 +33,7 @@ export {
   // Core objects
   Resource,
   jsonApiKoa,
+  jsonApiExpress,
   jsonApiWebSocket,
   Application,
   ApplicationInstance,

--- a/src/middlewares/json-api-express.ts
+++ b/src/middlewares/json-api-express.ts
@@ -1,0 +1,39 @@
+import * as express from "express";
+import { compose } from "compose-middleware";
+import Application from "../application";
+import ApplicationInstance from "../application-instance";
+
+import {
+  authenticate,
+  urlData,
+  handleBulkEndpoint,
+  handleJsonApiEndpoint,
+  convertErrorToHttpResponse
+} from "../utils/http-utils";
+
+export default function jsonApiExpress(app: Application) {
+  const jsonApiExpress = async (req: express.Request, res: express.Response, next: () => any) => {
+    const appInstance = new ApplicationInstance(app);
+
+    try {
+      await authenticate(appInstance, req);
+    } catch (error) {
+      res.status(error.status).json(convertErrorToHttpResponse(error));
+      return next();
+    }
+
+    req["href"] = `${req.protocol}://${req.get("host")}${req.originalUrl}`;
+    req["urlData"] = urlData(appInstance, req.path);
+
+    if (req.method === "PATCH" && req["urlData"].resource === "bulk") {
+      res.send(await handleBulkEndpoint(appInstance, req.body.operations));
+      return next();
+    }
+
+    const { body, status } = await handleJsonApiEndpoint(appInstance, req);
+    res.status(status).json(body);
+    return next();
+  };
+
+  return compose([express.json(), jsonApiExpress]);
+}

--- a/src/middlewares/json-api-koa.ts
+++ b/src/middlewares/json-api-koa.ts
@@ -1,141 +1,41 @@
-import * as escapeStringRegexp from "escape-string-regexp";
 import { Context, Middleware } from "koa";
 import * as koaBody from "koa-body";
 import * as compose from "koa-compose";
 
 import Application from "../application";
-import JsonApiErrors from "../errors/json-api-errors";
-import { JsonApiDocument, JsonApiErrorsDocument, Operation, OperationResponse } from "../types";
-import { parse } from "../utils/json-api-params";
-import { camelize, singularize } from "../utils/string";
 import ApplicationInstance from "../application-instance";
-import User from "../resources/user";
-import JsonApiError from "../errors/error";
-
-const STATUS_MAPPING = {
-  GET: 200,
-  POST: 201,
-  PATCH: 200,
-  PUT: 200,
-  DELETE: 204
-};
+import {
+  authenticate,
+  urlData,
+  handleBulkEndpoint,
+  handleJsonApiEndpoint,
+  convertErrorToHttpResponse
+} from "../utils/http-utils";
 
 export default function jsonApiKoa(app: Application, ...middlewares: Middleware[]) {
   const jsonApiKoa = async (ctx: Context, next: () => Promise<any>) => {
     const appInstance = new ApplicationInstance(app);
 
     try {
-      await authenticate(appInstance, ctx);
+      await authenticate(appInstance, ctx.request);
     } catch (error) {
       ctx.body = convertErrorToHttpResponse(error);
       ctx.status = error.status;
       return next();
     }
 
-    const data = urlData(appInstance, ctx);
+    ctx.request["urlData"] = urlData(appInstance, ctx.path);
 
-    if (ctx.method === "PATCH" && data.resource === "bulk") {
-      await handleBulkEndpoint(appInstance, ctx);
+    if (ctx.method === "PATCH" && ctx.request["urlData"].resource === "bulk") {
+      ctx.body = await handleBulkEndpoint(appInstance, ctx.request.body.operations);
       return next();
     }
 
-    ctx.urlData = data;
-    return handleJsonApiEndpoint(appInstance, ctx).then(() => next());
+    const { body, status } = await handleJsonApiEndpoint(appInstance, ctx.request);
+    ctx.body = body;
+    ctx.status = status;
+    return next();
   };
 
   return compose([koaBody({ json: true }), ...middlewares, jsonApiKoa]);
-}
-
-async function authenticate(appInstance: ApplicationInstance, ctx: Context) {
-  const authHeader = ctx.request.headers.authorization;
-  let currentUser: User;
-
-  if (authHeader && authHeader.startsWith("Bearer ")) {
-    const [, token] = authHeader.split(" ");
-    currentUser = await appInstance.getUserFromToken(token);
-  }
-
-  appInstance.user = currentUser;
-}
-
-function urlData(appInstance: ApplicationInstance, ctx: Context) {
-  const urlRegexp = new RegExp(
-    `^(\/+)?((?<namespace>${escapeStringRegexp(
-      appInstance.app.namespace
-    )})(\/+|$))?(?<resource>[^\\s\/?]+)?(\/+)?((?<id>[^\\s\/?]+)?(\/+)?\(?<relationships>relationships)?(\/+)?)?` +
-    "(?<relationship>[^\\s/?]+)?(/+)?$"
-  );
-
-  const { resource, id, relationships, relationship } = (ctx.path.match(urlRegexp) || {})["groups"] || ({} as any);
-
-  return {
-    id,
-    resource,
-    relationship,
-    isRelationships: !!relationships
-  };
-}
-
-async function handleBulkEndpoint(appInstance: ApplicationInstance, ctx: Context) {
-  const operations = await appInstance.app.executeOperations(ctx.request.body.operations || []);
-
-  ctx.body = { operations };
-}
-
-async function handleJsonApiEndpoint(appInstance: ApplicationInstance, ctx: Context) {
-  const op: Operation = convertHttpRequestToOperation(ctx);
-  if (["update", "remove"].includes(op.op) && !op.ref.id) return;
-
-  try {
-    const [result]: OperationResponse[] = await appInstance.app.executeOperations([op], appInstance);
-
-    ctx.body = convertOperationResponseToHttpResponse(ctx, result);
-    ctx.status = STATUS_MAPPING[ctx.method];
-  } catch (error) {
-    ctx.body = convertErrorToHttpResponse(error);
-    ctx.status = error.status || 500;
-  }
-}
-
-function convertHttpRequestToOperation(ctx: Context): Operation {
-  const { id, resource, relationship } = ctx.urlData;
-  const type = camelize(singularize(resource));
-
-  const opMap = {
-    GET: "get",
-    POST: "add",
-    PATCH: "update",
-    PUT: "update",
-    DELETE: "remove"
-  };
-
-  return {
-    op: opMap[ctx.method],
-    params: parse(ctx.href),
-    ref: { id, type, relationship },
-    data: ctx.request.body.data
-  } as Operation;
-}
-
-function convertOperationResponseToHttpResponse(ctx: Context, operation: OperationResponse): JsonApiDocument {
-  const responseMethods = ["GET", "POST", "PATCH", "PUT"];
-
-  if (responseMethods.includes(ctx.method)) {
-    return { data: operation.data, included: operation.included };
-  }
-}
-
-function convertErrorToHttpResponse(error: JsonApiError): JsonApiErrorsDocument {
-  const isJsonApiError = error && error.status;
-  if (!isJsonApiError) console.error("JSONAPI-TS: ", error);
-
-  const jsonApiError = isJsonApiError ? error : JsonApiErrors.UnhandledError();
-  if ((!process.env.NODE_ENV || process.env.NODE_ENV !== "production") && error.stack && !isJsonApiError) {
-    let firstLineErrorStack = error.stack.split("\n")[0];
-    if (firstLineErrorStack.indexOf('Error:') === 0) {
-      firstLineErrorStack = firstLineErrorStack.slice(7);
-    }
-    jsonApiError.detail = firstLineErrorStack;
-  }
-  return { errors: [jsonApiError] };
 }

--- a/src/utils/http-utils.ts
+++ b/src/utils/http-utils.ts
@@ -1,0 +1,134 @@
+import * as escapeStringRegexp from "escape-string-regexp";
+import { Request as ExpressRequest } from "express";
+import { Request as KoaRequest } from "koa";
+
+import JsonApiErrors from "../errors/json-api-errors";
+import { JsonApiDocument, JsonApiErrorsDocument, Operation, OperationResponse } from "../types";
+import { parse } from "../utils/json-api-params";
+import { camelize, singularize } from "../utils/string";
+import ApplicationInstance from "../application-instance";
+import User from "../resources/user";
+import JsonApiError from "../errors/error";
+
+const STATUS_MAPPING = {
+  GET: 200,
+  POST: 201,
+  PATCH: 200,
+  PUT: 200,
+  DELETE: 204
+};
+
+async function authenticate(appInstance: ApplicationInstance, request: ExpressRequest | KoaRequest) {
+  const authHeader = request.headers.authorization;
+  let currentUser: User;
+
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    const [, token] = authHeader.split(" ");
+    currentUser = await appInstance.getUserFromToken(token);
+  }
+
+  appInstance.user = currentUser;
+}
+
+function urlData(appInstance: ApplicationInstance, path: string) {
+  const urlRegexp = new RegExp(
+    `^(\/+)?((?<namespace>${escapeStringRegexp(
+      appInstance.app.namespace
+    )})(\/+|$))?(?<resource>[^\\s\/?]+)?(\/+)?((?<id>[^\\s\/?]+)?(\/+)?\(?<relationships>relationships)?(\/+)?)?` +
+    "(?<relationship>[^\\s/?]+)?(/+)?$"
+  );
+
+  const { resource, id, relationships, relationship } = (path.match(urlRegexp) || {})["groups"] || ({} as any);
+
+  return {
+    id,
+    resource,
+    relationship,
+    isRelationships: !!relationships
+  };
+}
+
+async function handleBulkEndpoint(
+  appInstance: ApplicationInstance,
+  operations: Operation[]
+): Promise<{ operations: OperationResponse[] }> {
+  return { operations: await appInstance.app.executeOperations(operations || []) };
+}
+
+async function handleJsonApiEndpoint(
+  appInstance: ApplicationInstance,
+  request: ExpressRequest | KoaRequest
+): Promise<{ body: JsonApiDocument | JsonApiErrorsDocument; status: number }> {
+  const op: Operation = convertHttpRequestToOperation(request);
+  if (["update", "remove"].includes(op.op) && !op.ref.id) return;
+
+  try {
+    const [result]: OperationResponse[] = await appInstance.app.executeOperations([op], appInstance);
+    return {
+      body: convertOperationResponseToHttpResponse(request, result),
+      status: STATUS_MAPPING[request.method]
+    };
+  } catch (error) {
+    return {
+      body: convertErrorToHttpResponse(error),
+      status: error.status || 500
+    };
+  }
+}
+
+function convertHttpRequestToOperation(req: ExpressRequest | KoaRequest): Operation {
+  const { id, resource, relationship } = req["urlData"];
+  const type = camelize(singularize(resource));
+
+  const opMap = {
+    GET: "get",
+    POST: "add",
+    PATCH: "update",
+    PUT: "update",
+    DELETE: "remove"
+  };
+
+  return {
+    op: opMap[req.method],
+    params: parse(req["href"]),
+    ref: { id, type, relationship },
+    data: (req.body || {}).data
+  } as Operation;
+}
+
+function convertOperationResponseToHttpResponse(
+  req: ExpressRequest | KoaRequest,
+  operation: OperationResponse
+): JsonApiDocument {
+  const responseMethods = ["GET", "POST", "PATCH", "PUT"];
+
+  if (responseMethods.includes(req.method)) {
+    return { data: operation.data, included: operation.included };
+  }
+}
+
+function convertErrorToHttpResponse(error: JsonApiError): JsonApiErrorsDocument {
+  const isJsonApiError = error && error.status;
+  if (!isJsonApiError) console.error("JSONAPI-TS: ", error);
+
+  const jsonApiError = isJsonApiError ? error : JsonApiErrors.UnhandledError();
+  if ((!process.env.NODE_ENV || process.env.NODE_ENV !== "production") && error.stack && !isJsonApiError) {
+    let firstLineErrorStack = error.stack.split("\n")[0];
+    if (firstLineErrorStack.indexOf("Error:") === 0) {
+      firstLineErrorStack = firstLineErrorStack.slice(7);
+    }
+    jsonApiError.detail = firstLineErrorStack;
+  }
+  return { errors: [jsonApiError] };
+}
+
+export {
+  STATUS_MAPPING,
+  authenticate,
+  urlData,
+  handleBulkEndpoint,
+  handleJsonApiEndpoint,
+  convertHttpRequestToOperation,
+  convertOperationResponseToHttpResponse,
+  convertErrorToHttpResponse
+};

--- a/tests/dummy-app/http.ts
+++ b/tests/dummy-app/http.ts
@@ -1,8 +1,13 @@
 import app from "./app";
 import * as Koa from "koa";
-import { jsonApiKoa } from "./jsonapi-ts";
+import * as express from "express";
+import { jsonApiKoa, jsonApiExpress } from "./jsonapi-ts";
 
-const koa = new Koa();
-koa.use(jsonApiKoa(app));
+const koaApp = new Koa();
+koaApp.use(jsonApiKoa(app));
 
-export default koa;
+const expressApp = express();
+expressApp.use(jsonApiExpress(app));
+
+export { expressApp, koaApp };
+export default koaApp;

--- a/tests/dummy-app/index.ts
+++ b/tests/dummy-app/index.ts
@@ -1,14 +1,15 @@
 import { Server } from "ws";
 import { jsonApiWebSocket } from "./jsonapi-ts";
 import app from "./app";
-import httpServer from "./http";
+import { koaApp, expressApp } from "./http";
 
-const server = httpServer.listen(3000);
+const koaServer = koaApp.listen(3000);
+const expressServer = expressApp.listen(3001);
 
 const ws = new Server({
-  server
+  server: koaServer
 });
 
 jsonApiWebSocket(ws, app);
 
-console.log("Server up on port 3000");
+console.log("Server up on port 3000 (koa) and 3001 (express)");

--- a/tests/test-suite/acceptance/article.test.ts
+++ b/tests/test-suite/acceptance/article.test.ts
@@ -1,10 +1,8 @@
-import { SuperTest, Test } from "supertest";
-import * as agent from "supertest-koa-agent";
 import articles from "./factories/article";
-import http from "../test-app/http";
 import getAuthenticationData from "./helpers/authenticateUser";
+import testTransportLayer from "./helpers/transportLayers";
 
-const request = agent(http) as SuperTest<Test>;
+const request = testTransportLayer("koa");
 
 describe("Articles", () => {
   describe("GET", () => {

--- a/tests/test-suite/acceptance/comment.test.ts
+++ b/tests/test-suite/acceptance/comment.test.ts
@@ -1,9 +1,7 @@
-import { SuperTest, Test } from "supertest";
-import * as agent from "supertest-koa-agent";
 import comments from "./factories/comment";
-import http from "../test-app/http";
+import testTransportLayer from "./helpers/transportLayers";
 
-const request = agent(http) as SuperTest<Test>;
+const request = testTransportLayer("express");
 
 describe("Comments", () => {
   describe("GET", () => {

--- a/tests/test-suite/acceptance/helpers/transportLayers.ts
+++ b/tests/test-suite/acceptance/helpers/transportLayers.ts
@@ -1,0 +1,10 @@
+import { koaApp, expressApp } from "../../test-app/http";
+import * as supertest from "supertest";
+import * as agent from "supertest-koa-agent";
+
+export default function testTransportLayer(transportLayer?: string) {
+  if (transportLayer === "express") {
+    return supertest(expressApp);
+  }
+  return agent(koaApp);
+}

--- a/tests/test-suite/acceptance/session.test.ts
+++ b/tests/test-suite/acceptance/session.test.ts
@@ -1,9 +1,7 @@
-import { SuperTest, Test } from "supertest";
-import * as agent from "supertest-koa-agent";
 import users from "./factories/user";
-import http from "../test-app/http";
+import testTransportLayer from "./helpers/transportLayers";
 
-const request = agent(http) as SuperTest<Test>;
+const request = testTransportLayer("koa");
 
 describe("Session", () => {
   it("POST", async () => {

--- a/tests/test-suite/acceptance/user.test.ts
+++ b/tests/test-suite/acceptance/user.test.ts
@@ -1,10 +1,8 @@
-import { SuperTest, Test } from "supertest";
-import * as agent from "supertest-koa-agent";
 import users from "./factories/user";
-import http from "../test-app/http";
 import getAuthenticationData from "./helpers/authenticateUser";
+import testTransportLayer from "./helpers/transportLayers";
 
-const request = agent(http) as SuperTest<Test>;
+const request = testTransportLayer("express");
 
 describe("Users", () => {
   describe("GET", () => {

--- a/tests/test-suite/acceptance/vote.test.ts
+++ b/tests/test-suite/acceptance/vote.test.ts
@@ -1,10 +1,8 @@
-import { SuperTest, Test } from "supertest";
-import * as agent from "supertest-koa-agent";
 import vote from "./factories/vote";
-import http from "../test-app/http";
 import getAuthenticationData from "./helpers/authenticateUser";
+import testTransportLayer from "./helpers/transportLayers";
 
-const request = agent(http) as SuperTest<Test>;
+const request = testTransportLayer("koa");
 
 describe("Votes", () => {
   describe("GET", () => {

--- a/tests/test-suite/test-app/app.ts
+++ b/tests/test-suite/test-app/app.ts
@@ -28,5 +28,5 @@ app.use(UserManagementAddon, {
   // userGenerateIdCallback: async () => (-Date.now()).toString(),
   // userEncryptPasswordCallback: encryptPassword
 } as UserManagementAddonOptions);
-app.services.knex = app.services.knex || Knex(knexfile["test_camelCase"]);
+app.services.knex = app.services.knex || Knex(knexfile["test_snake_case"]);
 export default app;

--- a/tests/test-suite/test-app/http.ts
+++ b/tests/test-suite/test-app/http.ts
@@ -1,8 +1,13 @@
 import app from "./app";
 import * as Koa from "koa";
-import { jsonApiKoa } from "./jsonapi-ts";
+import * as express from "express";
+import { jsonApiKoa, jsonApiExpress } from "./jsonapi-ts";
 
-const koa = new Koa();
-koa.use(jsonApiKoa(app));
+const koaApp = new Koa();
+koaApp.use(jsonApiKoa(app));
 
-export default koa;
+const expressApp = express();
+expressApp.use(jsonApiExpress(app));
+
+export { expressApp, koaApp };
+export default koaApp;

--- a/tests/test-suite/test-app/index.ts
+++ b/tests/test-suite/test-app/index.ts
@@ -1,14 +1,15 @@
 import { Server } from "ws";
 import { jsonApiWebSocket } from "./jsonapi-ts";
 import app from "./app";
-import httpServer from "./http";
+import { koaApp, expressApp } from "./http";
 
-const server = httpServer.listen(3000);
+const koaServer = koaApp.listen(3000);
+const expressServer = expressApp.listen(3001);
 
 const ws = new Server({
-  server
+  server: koaServer
 });
 
 jsonApiWebSocket(ws, app);
 
-console.log("Server up on port 3000");
+console.log("Server up on port 3000 (koa) and 3001 (express)");

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,6 +387,11 @@
     "@types/keygrip" "*"
     "@types/node" "*"
 
+"@types/debug@0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.31.tgz#bac8d8aab6a823e91deb7f79083b2a35fa638f33"
+  integrity sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -400,7 +405,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@*":
+"@types/express@*", "@types/express@^4.16.1":
   version "4.16.1"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.1.tgz#d756bd1a85c34d87eaf44c888bad27ba8a4b7cf0"
   integrity sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==
@@ -572,6 +577,14 @@ accepts@^1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+accepts@~1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
+  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+  dependencies:
+    mime-types "~2.1.24"
+    negotiator "0.6.2"
+
 acorn-globals@^4.1.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
@@ -709,6 +722,16 @@ array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array-flatten@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
+  integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
 array-slice@^1.0.0:
   version "1.1.0"
@@ -864,6 +887,22 @@ bluebird@^3.5.3:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
   integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
 
+body-parser@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+  integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
+  dependencies:
+    bytes "3.1.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.7.0"
+    raw-body "2.4.0"
+    type-is "~1.6.17"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -933,6 +972,11 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1151,6 +1195,15 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
+compose-middleware@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/compose-middleware/-/compose-middleware-5.0.1.tgz#4c0adb751afdde45d637a7a0b361095e510fafff"
+  integrity sha512-Rcv19QgPOtYHu8wDJsu4ehSfkqSXjQLwKRXhIy9TFiIijSZz330ORyLCeirb4sPuBBbDNC5lUvQLuM72vWjKSQ==
+  dependencies:
+    "@types/debug" "0.0.31"
+    array-flatten "^2.1.2"
+    debug "^4.1.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1161,14 +1214,14 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-content-disposition@~0.5.2:
+content-disposition@0.5.3, content-disposition@~0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
   integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
   dependencies:
     safe-buffer "5.1.2"
 
-content-type@^1.0.4:
+content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -1179,6 +1232,16 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+
+cookie@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
+  integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
 cookiejar@^2.1.0:
   version "2.1.2"
@@ -1267,6 +1330,13 @@ debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -1278,13 +1348,6 @@ debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
@@ -1364,7 +1427,7 @@ depd@^1.1.2, depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-destroy@^1.0.4:
+destroy@^1.0.4, destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
@@ -1441,6 +1504,11 @@ ember-cli-string-utils@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz#39b677fc2805f55173735376fcef278eaa4452a1"
   integrity sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=
 
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
 end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -1481,7 +1549,7 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escape-html@^1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -1535,6 +1603,11 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
 exec-sh@^0.3.2:
   version "0.3.2"
@@ -1590,6 +1663,42 @@ expect@^24.8.0:
     jest-matcher-utils "^24.8.0"
     jest-message-util "^24.8.0"
     jest-regex-util "^24.3.0"
+
+express@^4.17.1:
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
+  integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
+  dependencies:
+    accepts "~1.3.7"
+    array-flatten "1.1.1"
+    body-parser "1.19.0"
+    content-disposition "0.5.3"
+    content-type "~1.0.4"
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.5"
+    qs "6.7.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.1.2"
+    send "0.17.1"
+    serve-static "1.14.1"
+    setprototypeof "1.1.1"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1679,6 +1788,19 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+finalhandler@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1758,6 +1880,11 @@ formidable@^1.1.1, formidable@^1.2.0:
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
   integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
+forwarded@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
+  integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -1765,7 +1892,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fresh@~0.5.2:
+fresh@0.5.2, fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
@@ -2021,6 +2148,17 @@ http-errors@1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-errors@1.7.2, http-errors@~1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
+  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-errors@^1.6.3, http-errors@~1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.1.tgz#6a4ffe5d35188e1c39f872534690585852e1f027"
@@ -2126,6 +2264,11 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+ipaddr.js@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
+  integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -3338,6 +3481,11 @@ meow@^3.3.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
 merge-stream@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
@@ -3345,7 +3493,7 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
-methods@^1.1.1, methods@^1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -3369,6 +3517,11 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+mime-db@1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
 mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
@@ -3381,7 +3534,14 @@ mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.18, mime-types@~2.1.19:
   dependencies:
     mime-db "~1.37.0"
 
-mime@^1.4.1:
+mime-types@~2.1.24:
+  version "2.1.24"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  dependencies:
+    mime-db "1.40.0"
+
+mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -3448,7 +3608,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
@@ -3498,6 +3658,11 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+
+negotiator@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
+  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
 neo-async@^2.6.0:
   version "2.6.0"
@@ -3711,7 +3876,7 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-on-finished@^2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -3862,6 +4027,11 @@ parseurl@^1.3.2:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
   integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
 
+parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -3905,6 +4075,11 @@ path-root@^0.1.1:
   integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
   dependencies:
     path-root-regex "^0.1.0"
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -4029,6 +4204,14 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
+proxy-addr@~2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
+  integrity sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==
+  dependencies:
+    forwarded "~0.1.2"
+    ipaddr.js "1.9.0"
+
 psl@^1.1.24, psl@^1.1.28:
   version "1.1.31"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
@@ -4052,20 +4235,35 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+qs@6.7.0, qs@^6.5.1:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 qs@^6.4.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
   integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
 
-qs@^6.5.1:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
-  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
-
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 raw-body@^2.2.0:
   version "2.3.3"
@@ -4395,6 +4593,35 @@ semver@^6.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
   integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
 
+send@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
+  integrity sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.7.2"
+    mime "1.6.0"
+    ms "2.1.1"
+    on-finished "~2.3.0"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
+
+serve-static@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
+  integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.1"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -4424,6 +4651,11 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
+
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -4596,7 +4828,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0:
+"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0, statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -5048,6 +5280,14 @@ type-is@^1.6.14, type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+type-is@~1.6.17, type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
+
 typescript@^3.4:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.2.tgz#9ed4e6475d906f589200193be056f5913caed481"
@@ -5084,7 +5324,7 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-unpipe@1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
@@ -5127,6 +5367,11 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
 uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -5147,7 +5392,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@^1.1.2:
+vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
We now support Express!
The PR also refactors both the Express and Koa middlewares, extracting the shared functions into a separate http-utils file.

The tests now run both with Koa and Express. I added a simple function that makes switching a set of tests really easy.

I modified the docs to make sense of this new addition.

closes #28 