### PR TITLE
makes the params property optional

### DIFF
--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -8,7 +8,8 @@ import {
   ResourceSchemaRelationship,
   EagerLoadedData,
   DEFAULT_PRIMARY_KEY,
-  IJsonApiSerializer
+  IJsonApiSerializer,
+  JsonApiParams
 } from "../types";
 import pick from "../utils/pick";
 import promiseHashMap from "../utils/promise-hash-map";
@@ -106,8 +107,8 @@ export default class KnexProcessor<ResourceT extends Resource> extends Operation
 
     const records: KnexRecord[] = await this.getQuery()
       .where(queryBuilder => this.filtersToKnex(queryBuilder, filters))
-      .modify(queryBuilder => this.optionsBuilder(queryBuilder, op))
-      .select(getColumns(this.resourceClass, this.appInstance.app.serializer, op.params.fields));
+      .modify(queryBuilder => this.optionsBuilder(queryBuilder, params || {}))
+      .select(getColumns(this.resourceClass, this.appInstance.app.serializer, (params || {}).fields));
 
     if (!records.length && id) {
       throw JsonApiErrors.RecordNotExists();
@@ -231,8 +232,8 @@ export default class KnexProcessor<ResourceT extends Resource> extends Operation
     );
   }
 
-  optionsBuilder(queryBuilder: Knex.QueryBuilder, op: Operation) {
-    const { sort, page } = op.params;
+  optionsBuilder(queryBuilder: Knex.QueryBuilder, params: JsonApiParams) {
+    const { sort, page } = params;
     if (sort) {
       buildSortClause(sort, this.resourceClass, this.appInstance.app.serializer).forEach(({ field, direction }) => {
         queryBuilder.orderBy(field, direction);

--- a/src/processors/operation-processor.ts
+++ b/src/processors/operation-processor.ts
@@ -20,7 +20,7 @@ export default class OperationProcessor<ResourceT extends Resource> {
   protected attributes = {};
   protected relationships = {};
 
-  constructor(public appInstance: ApplicationInstance) {}
+  constructor(public appInstance: ApplicationInstance) { }
 
   async execute(op: Operation): Promise<ResourceT | ResourceT[] | void> {
     const action: string = op.op;
@@ -44,7 +44,7 @@ export default class OperationProcessor<ResourceT extends Resource> {
     record: HasId,
     eagerLoadedData: EagerLoadedData
   ) {
-    const typeFields = op.params.fields && op.params.fields[resourceClass.type];
+    const typeFields = op.params && op.params.fields && op.params.fields[resourceClass.type];
 
     const attributes = typeFields ? pick(this.attributes, typeFields) : this.attributes;
 
@@ -53,7 +53,8 @@ export default class OperationProcessor<ResourceT extends Resource> {
 
   async getAttributes(op: Operation, resourceClass: typeof Resource, record: HasId, eagerLoadedData: EagerLoadedData) {
     const attributeKeys =
-      (op.params.fields && op.params.fields[resourceClass.type]) || Object.keys(resourceClass.schema.attributes);
+      (op.params && op.params.fields && op.params.fields[resourceClass.type]) ||
+      Object.keys(resourceClass.schema.attributes);
     return pick(record, attributeKeys);
   }
 


### PR DESCRIPTION
This PR adds some null checks to both operationProcessor and knexProcessor, to allow for operations with no params property supplied:
![image](https://user-images.githubusercontent.com/10502605/58998295-765bf580-87d6-11e9-9e50-b5e5f7d03039.png)