### PR TITLE
Sets the knexProcessor as defaultProcessor

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -16,6 +16,7 @@ import ApplicationInstance from "./application-instance";
 import JsonApiSerializer from "./serializers/serializer";
 import Addon from "./addon";
 import { canAccessResource } from "./decorators/authorize";
+import KnexProcessor from "./processors/knex-processor";
 
 export default class Application {
   namespace: string;
@@ -38,7 +39,7 @@ export default class Application {
     this.types = settings.types || [];
     this.processors = settings.processors || [];
     this.services = settings.services || ({} as ApplicationServices);
-    this.defaultProcessor = settings.defaultProcessor || OperationProcessor;
+    this.defaultProcessor = settings.defaultProcessor || KnexProcessor;
     this.addons = [];
     this.serializer = new (settings.serializer || JsonApiSerializer)();
   }

--- a/tests/test-suite/test-app/app.ts
+++ b/tests/test-suite/test-app/app.ts
@@ -14,8 +14,7 @@ import { ApplicationInstance } from "../../../src";
 const app = new Application({
   namespace: "api",
   types: [Article, Comment, Vote],
-  processors: [ArticleProcessor, VoteProcessor],
-  defaultProcessor: KnexProcessor
+  processors: [ArticleProcessor, VoteProcessor]
 });
 
 app.use(UserManagementAddon, {


### PR DESCRIPTION
This PR sets as the defaultProcessor the knexProcessor, if none is provided.

It's a change to reduce the number of things a dev has to do when setting up a project. Especially an external dev that doesn't know the code or the way jsonapi-ts works.

It's something that I found while making a template for an API for jsonapi-ts.
While we aren't dependant of the knex processor, the reality is that in most of the APIs that will be the default processor.