### PR TITLE
Relationship to column and vice versa param optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -137,12 +137,12 @@ export type PasswordConstructor = typeof Password;
 
 export type ResourceSchemaAttributes = {
   [key: string]:
-    | StringConstructor
-    | NumberConstructor
-    | BooleanConstructor
-    | ArrayConstructor
-    | ObjectConstructor
-    | PasswordConstructor;
+  | StringConstructor
+  | NumberConstructor
+  | BooleanConstructor
+  | ArrayConstructor
+  | ObjectConstructor
+  | PasswordConstructor;
 };
 
 export type ResourceSchemaRelationships = {
@@ -173,8 +173,8 @@ export interface IJsonApiSerializer {
   resourceTypeToTableName(resourceType: string): string;
   attributeToColumn(attributeName: string): string;
   columnToAttribute(columnName: string): string;
-  relationshipToColumn(relationshipName: string, primaryKeyName: string): string;
-  columnToRelationship(columnName: string, primaryKeyName: string): string;
+  relationshipToColumn(relationshipName: string, primaryKeyName?: string): string;
+  columnToRelationship(columnName: string, primaryKeyName?: string): string;
   foreignResourceToForeignTableName(foreignResourceType: string, prefix?: string): string;
   deserializeResource(op: Operation, resourceClass: typeof Resource): Operation;
   serializeResource(resource: Resource, resourceType: typeof Resource): Resource;

--- a/tests/test-suite/test-app/processors/article.ts
+++ b/tests/test-suite/test-app/processors/article.ts
@@ -11,7 +11,7 @@ export default class ArticleProcessor<ResourceT extends Article> extends KnexPro
 
       const [result] = await processor
         .getQuery()
-        .where({ [this.appInstance.app.serializer.relationshipToColumn('article', 'id')]: article.id })
+        .where({ [this.appInstance.app.serializer.relationshipToColumn('article')]: article.id })
         .count();
 
       return result["count(*)"];


### PR DESCRIPTION
As in the serializer we have default values for the primaryKeyName:
![image](https://user-images.githubusercontent.com/10502605/59128360-357ff000-8940-11e9-85be-54bcd710fc1e.png)
This is a type only change, to ease the development of custom operations/properties.
A test modification is included to show a use-case of the repercussions of the change