### PR TITLE
Error expressiveness improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,12 +776,13 @@ export default class ReadOnlyProcessor extends OperationProcessor<Resource> {
           relationships: {}
         };
       } catch {
-        throw JsonApiErrors.UnhandledError();
+        throw JsonApiErrors.UnhandledError("Error while reading file");
       }
     });
   }
 }
 ```
+> ℹ️ Notice that you can provide details (like in the previous example) but it's not mandatory.
 
 You can also create an error by using the `JsonApiError` type:
 

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -19,8 +19,6 @@ export default class JsonApiError extends Error implements IJsonApiError {
 
     this.status = status;
     this.code = code;
-    if (detail) {
-      this.detail = detail;
-    }
+    this.detail = detail;
   }
 }

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -14,10 +14,13 @@ export default class JsonApiError extends Error implements IJsonApiError {
     about?: string;
   };
 
-  constructor(status: HttpStatusCode, code: string) {
+  constructor(status: HttpStatusCode, code: string, detail?: string) {
     super(`${status}: ${code}`);
 
     this.status = status;
     this.code = code;
+    if (detail) {
+      this.detail = detail;
+    }
   }
 }

--- a/src/errors/json-api-errors.ts
+++ b/src/errors/json-api-errors.ts
@@ -2,11 +2,11 @@ import { HttpStatusCode } from "../types";
 import JsonApiError from "./error";
 
 export default {
-  UnhandledError: () => new JsonApiError(HttpStatusCode.InternalServerError, "unhandled_error"),
-  AccessDenied: () => new JsonApiError(HttpStatusCode.Forbidden, "access_denied"),
-  Unauthorized: () => new JsonApiError(HttpStatusCode.Unauthorized, "unauthorized"),
-  RecordNotExists: () => new JsonApiError(HttpStatusCode.NotFound, "not_found"),
-  InvalidToken: () => new JsonApiError(HttpStatusCode.UnprocessableEntity, "invalid_token"),
-  InvalidData: () => new JsonApiError(HttpStatusCode.UnprocessableEntity, "invalid_data"),
-  BadRequest: () => new JsonApiError(HttpStatusCode.BadRequest, "bad_request")
+  UnhandledError: (detail?: string) => new JsonApiError(HttpStatusCode.InternalServerError, "unhandled_error", detail),
+  AccessDenied: (detail?: string) => new JsonApiError(HttpStatusCode.Forbidden, "access_denied", detail),
+  Unauthorized: (detail?: string) => new JsonApiError(HttpStatusCode.Unauthorized, "unauthorized", detail),
+  RecordNotExists: (detail?: string) => new JsonApiError(HttpStatusCode.NotFound, "not_found", detail),
+  InvalidToken: (detail?: string) => new JsonApiError(HttpStatusCode.UnprocessableEntity, "invalid_token", detail),
+  InvalidData: (detail?: string) => new JsonApiError(HttpStatusCode.UnprocessableEntity, "invalid_data", detail),
+  BadRequest: (detail?: string) => new JsonApiError(HttpStatusCode.BadRequest, "bad_request", detail)
 };


### PR DESCRIPTION
This PR solves the first goal expressed in #183, by giving a more clear error:
![image](https://user-images.githubusercontent.com/10502605/59131798-c14a4a00-8949-11e9-8a22-22f2b78cf8f4.png)

And it extends error creation, so that we (and users) can extend error creation to provide more details in each case.